### PR TITLE
feat: add `svelte/no-reactive-reassign` rule

### DIFF
--- a/.changeset/tidy-pugs-draw.md
+++ b/.changeset/tidy-pugs-draw.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": minor
+---
+
+feat: add `svelte/no-reactive-reassign` rule

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ These rules relate to possible syntax or logic errors in Svelte code:
 | [svelte/no-export-load-in-svelte-module-in-kit-pages](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-export-load-in-svelte-module-in-kit-pages/) | disallow exporting load functions in `*.svelte` module in Svelte Kit page components. |  |
 | [svelte/no-not-function-handler](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-not-function-handler/) | disallow use of not function in event handler | :star: |
 | [svelte/no-object-in-text-mustaches](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-object-in-text-mustaches/) | disallow objects in text mustache interpolation | :star: |
+| [svelte/no-reactive-reassign](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-reactive-reassign/) | disallow reassigning reactive values |  |
 | [svelte/no-shorthand-style-property-overrides](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-shorthand-style-property-overrides/) | disallow shorthand style properties that override related longhand properties | :star: |
 | [svelte/no-store-async](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-store-async/) | disallow using async/await inside svelte stores because it causes issues with the auto-unsubscribing features |  |
 | [svelte/no-unknown-style-directive-property](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unknown-style-directive-property/) | disallow unknown `style:property` | :star: |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -26,6 +26,7 @@ These rules relate to possible syntax or logic errors in Svelte code:
 | [svelte/no-export-load-in-svelte-module-in-kit-pages](./rules/no-export-load-in-svelte-module-in-kit-pages.md) | disallow exporting load functions in `*.svelte` module in Svelte Kit page components. |  |
 | [svelte/no-not-function-handler](./rules/no-not-function-handler.md) | disallow use of not function in event handler | :star: |
 | [svelte/no-object-in-text-mustaches](./rules/no-object-in-text-mustaches.md) | disallow objects in text mustache interpolation | :star: |
+| [svelte/no-reactive-reassign](./rules/no-reactive-reassign.md) | disallow reassigning reactive values |  |
 | [svelte/no-shorthand-style-property-overrides](./rules/no-shorthand-style-property-overrides.md) | disallow shorthand style properties that override related longhand properties | :star: |
 | [svelte/no-store-async](./rules/no-store-async.md) | disallow using async/await inside svelte stores because it causes issues with the auto-unsubscribing features |  |
 | [svelte/no-unknown-style-directive-property](./rules/no-unknown-style-directive-property.md) | disallow unknown `style:property` | :star: |

--- a/docs/rules/no-reactive-reassign.md
+++ b/docs/rules/no-reactive-reassign.md
@@ -1,0 +1,122 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "svelte/no-reactive-reassign"
+description: "disallow reassigning reactive values"
+---
+
+# svelte/no-reactive-reassign
+
+> disallow reassigning reactive values
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+
+## :book: Rule Details
+
+This rule aims to prevent unintended behavior caused by modification or reassignment of reactive values.
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/no-reactive-reassign: "error" */
+  let value = 0
+  $: reactiveValue = value * 2
+
+  function handleClick() {
+    /* ✓ GOOD */
+    value++
+    /* ✗ BAD */
+    reactiveValue = value * 3
+    reactiveValue++
+  }
+</script>
+
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- ✗ BAD -->
+<input type="number" bind:value={reactiveValue} />
+```
+
+</ESLintCodeBlock>
+
+## :wrench: Options
+
+```json
+{
+  "svelte/no-reactive-reassign": ["error", {
+    "props": true
+  }]
+}
+```
+
+- `props` ... If set to `true`, this rule warns against the modification of reactive value properties. Default is `true`.
+
+### `{ "props": true }`
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/no-reactive-reassign: ["error", { "props": true }] */
+  let value = 0
+  $: reactiveValue = { value: value * 2}
+
+  function handleClick() {
+    /* ✓ GOOD */
+    value++
+    /* ✗ BAD */
+    reactiveValue.value++
+    reactiveValue = { value: reactiveValue.value + 1 }
+  }
+</script>
+
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- ✗ BAD -->
+<input type="number" bind:value={reactiveValue.value} />
+<MyComponent bind:objectValue={reactiveValue} />
+```
+
+</ESLintCodeBlock>
+
+### `{ "props": false }`
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/no-reactive-reassign: ["error", { "props": false }] */
+  let value = 0
+  $: reactiveValue = { value: value * 2}
+
+  function handleClick() {
+    /* ✓ GOOD */
+    value++
+    /* OK */
+    reactiveValue.value++
+    /* ✗ BAD */
+    reactiveValue = { value: reactiveValue.value + 1 }
+  }
+</script>
+
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- OK -->
+<input type="number" bind:value={reactiveValue.value} />
+<!-- ✗ BAD -->
+<MyComponent bind:objectValue={reactiveValue} />
+```
+
+</ESLintCodeBlock>
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-reactive-reassign.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-reactive-reassign.ts)

--- a/src/rules/no-reactive-reassign.ts
+++ b/src/rules/no-reactive-reassign.ts
@@ -187,6 +187,21 @@ export default createRule("no-reactive-reassign", {
         }
         return null
       },
+      [TSESTree.AST_NODE_TYPES.RestElement]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.RestElement>) => {
+        if (parent.argument === node && parent.parent) {
+          // The context to check next for `({...foo} = obj)`.
+          return {
+            type: "check",
+            node: parent.parent as
+              | TSESTree.ArrayPattern
+              | TSESTree.ObjectPattern,
+          }
+        }
+        return null
+      },
       SvelteDirective: ({
         node,
         parent,

--- a/src/rules/no-reactive-reassign.ts
+++ b/src/rules/no-reactive-reassign.ts
@@ -1,0 +1,281 @@
+import { TSESTree } from "@typescript-eslint/types"
+import type { AST } from "svelte-eslint-parser"
+import { createRule } from "../utils"
+import { getPropertyName } from "@eslint-community/eslint-utils"
+
+export default createRule("no-reactive-reassign", {
+  meta: {
+    docs: {
+      description: "disallow reassigning reactive values",
+      category: "Possible Errors",
+      // TODO Switch to recommended in the major version.
+      recommended: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          props: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      assignmentToReactiveValue: "Assignment to reactive value '{{name}}'.",
+      assignmentToReactiveValueProp:
+        "Assignment to property of reactive value '{{name}}'.",
+    },
+    type: "problem",
+  },
+  create(context) {
+    const props = context.options[0]?.props !== false // default true
+    const sourceCode = context.getSourceCode()
+    const scopeManager = sourceCode.scopeManager
+    const globalScope = scopeManager.globalScope
+    const toplevelScope =
+      globalScope?.childScopes.find((scope) => scope.type === "module") ||
+      globalScope
+    if (!globalScope || !toplevelScope) {
+      return {}
+    }
+
+    type CheckContext<P extends TSESTree.Node | AST.SvelteDirective> = {
+      node: TSESTree.Expression
+      parent: P
+      pathNodes: TSESTree.MemberExpression[]
+    }
+    const CHECK_REASSIGN: {
+      [key in TSESTree.Node["type"] | "SvelteDirective"]?: (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Ignore
+        ctx: CheckContext<any>,
+      ) =>
+        | null // The given expression does not reassign.
+        // The given expression will reassign.
+        | {
+            type: "reassign"
+            node: TSESTree.Node | AST.SvelteNode
+            pathNodes?: TSESTree.MemberExpression[]
+          }
+        // The context to check next.
+        | {
+            type: "check"
+            node: TSESTree.Expression
+            pathNodes?: TSESTree.MemberExpression[]
+          }
+    } = {
+      [TSESTree.AST_NODE_TYPES.UpdateExpression]:
+        // e.g. foo ++, foo --
+        ({ parent }) => ({ type: "reassign", node: parent }),
+      [TSESTree.AST_NODE_TYPES.UnaryExpression]: ({
+        parent,
+      }: CheckContext<TSESTree.UnaryExpression>) => {
+        if (parent.operator === "delete") {
+          // e.g. delete foo.prop
+          return { type: "reassign", node: parent }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.AssignmentExpression]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.AssignmentExpression>) => {
+        if (parent.left === node) {
+          // e.g. foo = 42, foo += 42, foo -= 42
+          return { type: "reassign", node: parent }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.ForInStatement]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.ForInStatement>) => {
+        if (parent.left === node) {
+          // e.g. for (foo in itr)
+          return { type: "reassign", node: parent }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.ForOfStatement]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.ForOfStatement>) => {
+        if (parent.left === node) {
+          // e.g. for (foo of itr)
+          return { type: "reassign", node: parent }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.CallExpression]: ({
+        node,
+        parent,
+        pathNodes,
+      }: CheckContext<TSESTree.CallExpression>) => {
+        if (pathNodes.length > 0 && parent.callee === node) {
+          const mem = pathNodes[pathNodes.length - 1]
+          const callName = getPropertyName(mem)
+          if (
+            callName &&
+            /^(?:push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill)$/u.test(
+              callName,
+            )
+          ) {
+            // e.g. foo.push()
+            return {
+              type: "reassign",
+              node: parent,
+              pathNodes: pathNodes.slice(0, -1),
+            }
+          }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.MemberExpression]: ({
+        node,
+        parent,
+        pathNodes,
+      }: CheckContext<TSESTree.MemberExpression>) => {
+        if (parent.object === node) {
+          // The context to check next.
+          return {
+            type: "check",
+            node: parent,
+            pathNodes: [...pathNodes, parent],
+          }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.ChainExpression]: ({
+        parent,
+      }: CheckContext<TSESTree.ChainExpression>) => {
+        // e.g. `foo?.prop`
+        // The context to check next.
+        return { type: "check", node: parent }
+      },
+      [TSESTree.AST_NODE_TYPES.ConditionalExpression]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.ConditionalExpression>) => {
+        if (parent.test === node) {
+          return null
+        }
+        // The context to check next for `(test ? foo : bar).prop`.
+        return { type: "check", node: parent }
+      },
+      [TSESTree.AST_NODE_TYPES.Property]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.Property>) => {
+        if (
+          parent.value === node &&
+          parent.parent &&
+          parent.parent.type === "ObjectPattern"
+        ) {
+          // The context to check next for `({a: foo} = obj)`.
+          return { type: "check", node: parent.parent }
+        }
+        return null
+      },
+      [TSESTree.AST_NODE_TYPES.ArrayPattern]: ({
+        node,
+        parent,
+      }: CheckContext<TSESTree.ArrayPattern>) => {
+        if (parent.elements.includes(node as TSESTree.DestructuringPattern)) {
+          // The context to check next for `([foo] = obj)`.
+          return { type: "check", node: parent }
+        }
+        return null
+      },
+      SvelteDirective: ({
+        node,
+        parent,
+      }: CheckContext<AST.SvelteDirective>) => {
+        if (parent.kind !== "Binding") {
+          return null
+        }
+        if (parent.shorthand || parent.expression === node) {
+          return {
+            type: "reassign",
+            node: parent,
+          }
+        }
+        return null
+      },
+    }
+
+    /**
+     * Returns the reassign information for the given expression node if it has a reassign.
+     */
+    function getReassignData(expr: TSESTree.Expression) {
+      let pathNodes: TSESTree.MemberExpression[] = []
+      let node: TSESTree.Expression = expr
+      let parent
+      while ((parent = node.parent)) {
+        const check = CHECK_REASSIGN[parent.type]
+        if (!check) {
+          return null
+        }
+        const result = check({ node, parent, pathNodes })
+        if (!result) {
+          return null
+        }
+        pathNodes = result.pathNodes || pathNodes
+        if (result.type === "reassign") {
+          return {
+            node: result.node,
+            pathNodes,
+          }
+        }
+        node = result.node
+      }
+      return null
+    }
+
+    return {
+      SvelteReactiveStatement(node: AST.SvelteReactiveStatement) {
+        if (
+          node.body.type !== "ExpressionStatement" ||
+          node.body.expression.type !== "AssignmentExpression" ||
+          node.body.expression.operator !== "="
+        ) {
+          return
+        }
+        const assignment = node.body.expression
+        for (const variable of toplevelScope.variables) {
+          if (!variable.defs.some((def) => def.node === assignment)) {
+            continue
+          }
+          for (const reference of variable.references) {
+            const id = reference.identifier
+            if (
+              (assignment.left.range[0] <= id.range[0] &&
+                id.range[1] <= assignment.left.range[1]) ||
+              id.type === "JSXIdentifier"
+            ) {
+              continue
+            }
+            const reassign = getReassignData(id)
+            if (!reassign) {
+              continue
+            }
+
+            // Suppresses reporting if the props option is set to `false` and reassigned to properties.
+            if (!props && reassign.pathNodes.length > 0) continue
+
+            context.report({
+              node: reassign.node,
+              messageId:
+                reassign.pathNodes.length === 0
+                  ? "assignmentToReactiveValue"
+                  : "assignmentToReactiveValueProp",
+              data: {
+                name: id.name,
+              },
+            })
+          }
+        }
+      },
+    }
+  },
+})

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -29,6 +29,7 @@ import noNotFunctionHandler from "../rules/no-not-function-handler"
 import noObjectInTextMustaches from "../rules/no-object-in-text-mustaches"
 import noReactiveFunctions from "../rules/no-reactive-functions"
 import noReactiveLiterals from "../rules/no-reactive-literals"
+import noReactiveReassign from "../rules/no-reactive-reassign"
 import noShorthandStylePropertyOverrides from "../rules/no-shorthand-style-property-overrides"
 import noSpacesAroundEqualSignsInAttribute from "../rules/no-spaces-around-equal-signs-in-attribute"
 import noStoreAsync from "../rules/no-store-async"
@@ -84,6 +85,7 @@ export const rules = [
   noObjectInTextMustaches,
   noReactiveFunctions,
   noReactiveLiterals,
+  noReactiveReassign,
   noShorthandStylePropertyOverrides,
   noSpacesAroundEqualSignsInAttribute,
   noStoreAsync,

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/array01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/array01-errors.yaml
@@ -1,0 +1,36 @@
+- message: Assignment to reactive value 'array1'.
+  line: 15
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array2'.
+  line: 16
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array3'.
+  line: 17
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array4'.
+  line: 18
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array5'.
+  line: 19
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array6'.
+  line: 20
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array7'.
+  line: 21
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array8'.
+  line: 22
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'array9'.
+  line: 23
+  column: 5
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/array01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/array01-input.svelte
@@ -1,0 +1,41 @@
+<script>
+  let rerender = 0
+  let value = "abc123"
+  $: array1 = [...value]
+  $: array2 = [...value]
+  $: array3 = [...value]
+  $: array4 = [...value]
+  $: array5 = [...value]
+  $: array6 = [...value]
+  $: array7 = [...value]
+  $: array8 = [...value]
+  $: array9 = [...value]
+
+  function handleClick() {
+    array1.push(42)
+    array2.pop()
+    array3.shift()
+    array4.unshift(42)
+    array5.reverse()
+    array6.splice(1, 1)
+    array7.sort()
+    array8.copyWithin(0, 3, 4)
+    array9.fill(42)
+    rerender++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+
+<input bind:value />
+
+{JSON.stringify(array1) +
+  JSON.stringify(array2) +
+  JSON.stringify(array3) +
+  JSON.stringify(array4) +
+  JSON.stringify(array5) +
+  JSON.stringify(array6) +
+  JSON.stringify(array7) +
+  JSON.stringify(array8) +
+  JSON.stringify(array9) +
+  rerender}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/bind-dir01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/bind-dir01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 6
+  column: 22
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/bind-dir01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/bind-dir01-input.svelte
@@ -1,0 +1,6 @@
+<script>
+  let value = 0
+  $: reactiveValue = value * 2
+</script>
+
+<input type="number" bind:value={reactiveValue} />

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/conditional01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/conditional01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 7
+  column: 6
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/conditional01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/conditional01-input.svelte
@@ -1,0 +1,13 @@
+<script>
+  let object = { value: 0 }
+  $: reactiveValue = { value: object.value * 2 }
+
+  function handleClick() {
+    let a = {}
+    ;(a ? reactiveValue : {}).value = 42
+    // OK
+    ;(reactiveValue ? a : {}).value = 42
+  }
+</script>
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/delete01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/delete01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 7
+  column: 5
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/delete01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/delete01-input.svelte
@@ -1,0 +1,11 @@
+<script>
+  let object = { value: 0 }
+  $: reactiveValue = { value: object.value * 2 }
+
+  function handleClick() {
+    delete object.value
+    delete reactiveValue.value
+  }
+</script>
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/destructure01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/destructure01-errors.yaml
@@ -1,0 +1,16 @@
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 9
+  column: 7
+  suggestions: null
+- message: Assignment to reactive value 'reactiveObject'.
+  line: 10
+  column: 7
+  suggestions: null
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 12
+  column: 6
+  suggestions: null
+- message: Assignment to reactive value 'reactiveArray'.
+  line: 13
+  column: 6
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/destructure01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/destructure01-input.svelte
@@ -1,0 +1,19 @@
+<script>
+  let value = 0
+  $: reactiveValue = value * 2
+  $: reactiveObject = { value }
+  $: reactiveArray = [value]
+
+  function handleClick() {
+    let o = { foo: 42 }
+    ;({ foo: reactiveValue } = o)
+    ;({ ...reactiveObject } = o)
+    let a = [42]
+    ;[reactiveValue] = a
+    ;[...reactiveArray] = a
+  }
+</script>
+
+{reactiveValue}
+{JSON.stringify(reactiveObject)}
+{JSON.stringify(reactiveArray)}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/for-in01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/for-in01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 8
+  column: 5
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/for-in01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/for-in01-input.svelte
@@ -1,0 +1,19 @@
+<script>
+  let rerender = 0
+  let value = "a"
+  $: reactiveValue = { key: value + value }
+  let object = { key: 42 }
+
+  function handleClick() {
+    for (reactiveValue.key in object) {
+      console.log(reactiveValue.key)
+    }
+    rerender++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+
+<input bind:value />
+
+{reactiveValue.key + rerender}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/for-of01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/for-of01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 8
+  column: 5
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/for-of01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/for-of01-input.svelte
@@ -1,0 +1,19 @@
+<script>
+  let rerender = 0
+  let value = "a"
+  $: reactiveValue = { key: value + value }
+  let object = [42]
+
+  function handleClick() {
+    for (reactiveValue.key of object) {
+      console.log(reactiveValue.key)
+    }
+    rerender++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+
+<input bind:value />
+
+{reactiveValue.key + rerender}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/member01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/member01-errors.yaml
@@ -1,0 +1,8 @@
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 6
+  column: 5
+  suggestions: null
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 8
+  column: 6
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/member01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/member01-input.svelte
@@ -1,0 +1,12 @@
+<script>
+  let object = { value: 0 }
+  $: reactiveValue = { value: object.value * 2, foo: { bar: object.value * 2 } }
+
+  function handleClick() {
+    reactiveValue.value = 42
+    // eslint-disable-next-line no-unsafe-optional-chaining -- ignore
+    ;(reactiveValue?.foo).bar = 42
+  }
+</script>
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/props-false/_config.json
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/props-false/_config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "props": false
+    }
+  ]
+}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/props-false/test01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/props-false/test01-errors.yaml
@@ -1,0 +1,8 @@
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 7
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 15
+  column: 22
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/props-false/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/props-false/test01-input.svelte
@@ -1,0 +1,17 @@
+<script>
+  let value = 0
+  $: reactiveValue = value * 2
+
+  function handleClick() {
+    /* ✗ BAD */
+    reactiveValue++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- ✗ BAD -->
+<input type="number" bind:value={reactiveValue} />
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/props-true01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/props-true01-errors.yaml
@@ -1,0 +1,8 @@
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 9
+  column: 5
+  suggestions: null
+- message: Assignment to property of reactive value 'reactiveValue'.
+  line: 16
+  column: 22
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/props-true01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/props-true01-input.svelte
@@ -1,0 +1,16 @@
+<script>
+  let value = 0
+  $: reactiveValue = { value: value * 2 }
+
+  function handleClick() {
+    /* ✓ GOOD */
+    value++
+    /* ✗ BAD */
+    reactiveValue.value++
+  }
+</script>
+
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- ✗ BAD -->
+<input type="number" bind:value={reactiveValue.value} />

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/test01-errors.yaml
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/test01-errors.yaml
@@ -1,0 +1,12 @@
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 7
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 8
+  column: 5
+  suggestions: null
+- message: Assignment to reactive value 'reactiveValue'.
+  line: 16
+  column: 22
+  suggestions: null

--- a/tests/fixtures/rules/no-reactive-reassign/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/invalid/test01-input.svelte
@@ -1,0 +1,18 @@
+<script>
+  let value = 0
+  $: reactiveValue = value * 2
+
+  function handleClick() {
+    /* ✗ BAD */
+    reactiveValue = value * 3
+    reactiveValue++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- ✗ BAD -->
+<input type="number" bind:value={reactiveValue} />
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/array01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/array01-input.svelte
@@ -1,0 +1,41 @@
+<script>
+  let rerender = 0
+  let value = "abc123"
+  $: array1 = [...value]
+  $: array2 = [...value]
+  $: array3 = [...value]
+  $: array4 = [...value]
+  $: array5 = [...value]
+  $: array6 = [...value]
+  $: array7 = [...value]
+  $: array8 = [...value]
+  $: array9 = [...value]
+
+  function handleClick() {
+    ;[...array1].push(42)
+    array2.slice().pop()
+    array3.concat().shift()
+    array4.filter(Boolean).unshift(42)
+    array5.map((a) => a).reverse()
+    array6.flat().splice(1, 1)
+    array7.flatMap((a) => a).sort()
+    Object.keys(array8).copyWithin(0, 3, 4)
+    Object.values(array9).fill(42)
+    rerender++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+
+<input bind:value />
+
+{JSON.stringify(array1) +
+  JSON.stringify(array2) +
+  JSON.stringify(array3) +
+  JSON.stringify(array4) +
+  JSON.stringify(array5) +
+  JSON.stringify(array6) +
+  JSON.stringify(array7) +
+  JSON.stringify(array8) +
+  JSON.stringify(array9) +
+  rerender}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/assign-right01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/assign-right01-input.svelte
@@ -1,10 +1,13 @@
 <script>
   let object = 0
   $: reactiveValue = value * 2
+  let foo
 
   function handleClick() {
-    let foo = reactiveValue
+    foo = reactiveValue
     console.log(foo)
+    let bar = reactiveValue
+    console.log(bar)
   }
 </script>
 

--- a/tests/fixtures/rules/no-reactive-reassign/valid/assign-right01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/assign-right01-input.svelte
@@ -1,0 +1,11 @@
+<script>
+  let object = 0
+  $: reactiveValue = value * 2
+
+  function handleClick() {
+    let foo = reactiveValue
+    console.log(foo)
+  }
+</script>
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/destructure01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/destructure01-input.svelte
@@ -1,0 +1,12 @@
+<script>
+  let value = 0
+  $: reactiveValue = value * 2
+
+  function handleClick() {
+    let o = { 4: 42 }
+    let a
+    ;({ [reactiveValue]: a } = o)
+  }
+</script>
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/for-in01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/for-in01-input.svelte
@@ -1,0 +1,19 @@
+<script>
+  let rerender = 0
+  let value = "a"
+  $: reactiveValue = { key: value + value }
+  let object = { key: 42 }
+
+  function handleClick() {
+    for (object.key in reactiveValue) {
+      console.log(reactiveValue.key)
+    }
+    rerender++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+
+<input bind:value />
+
+{reactiveValue.key + rerender}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/for-of01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/for-of01-input.svelte
@@ -1,0 +1,19 @@
+<script>
+  let rerender = 0
+  let value = "a"
+  $: reactiveValue = [value + value]
+  let object = 2
+
+  function handleClick() {
+    for (object of reactiveValue) {
+      console.log(object)
+    }
+    rerender++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+
+<input bind:value />
+
+{reactiveValue[0] + rerender}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/member-key01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/member-key01-input.svelte
@@ -1,0 +1,10 @@
+<script>
+  let object = { value: 0 }
+  $: reactiveValue = { key: "value", value: object.value * 2 }
+
+  function handleClick() {
+    object[reactiveValue.key] = 42
+  }
+</script>
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/on-dir01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/on-dir01-input.svelte
@@ -1,0 +1,8 @@
+<script>
+  let value = 0
+  $: reactiveFn =
+    value % 2 ? () => console.log("odd") : () => console.log("even")
+</script>
+
+<button on:click={reactiveFn} />
+<input type="number" bind:value />

--- a/tests/fixtures/rules/no-reactive-reassign/valid/props-false/_config.json
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/props-false/_config.json
@@ -1,0 +1,7 @@
+{
+  "options": [
+    {
+      "props": false
+    }
+  ]
+}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/props-false/props-false01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/props-false/props-false01-input.svelte
@@ -1,0 +1,16 @@
+<script>
+  let value = 0
+  $: reactiveValue = { value: value * 2 }
+
+  function handleClick() {
+    /* ✓ GOOD */
+    value++
+    /* ✗ BAD */
+    reactiveValue.value++
+  }
+</script>
+
+<!-- ✓ GOOD -->
+<input type="number" bind:value />
+<!-- ✗ BAD -->
+<input type="number" bind:value={reactiveValue.value} />

--- a/tests/fixtures/rules/no-reactive-reassign/valid/reactive-like01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/reactive-like01-input.svelte
@@ -1,0 +1,14 @@
+<script>
+  let value = 0
+  let reactiveLikeValue
+  $: reactiveLikeValue = value * 2
+
+  function handleClick() {
+    reactiveLikeValue++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+<input type="number" bind:value />
+
+{reactiveLikeValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/reactive-like02-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/reactive-like02-input.svelte
@@ -1,0 +1,16 @@
+<script>
+  let value = 0
+  let reactiveLikeValue
+  $: {
+    reactiveLikeValue = value * 2
+  }
+
+  function handleClick() {
+    reactiveLikeValue++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+<input type="number" bind:value />
+
+{reactiveLikeValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/test01-input.svelte
@@ -1,0 +1,14 @@
+<script>
+  let value = 0
+  $: reactiveValue = value * 2
+
+  function handleClick() {
+    /* ✓ GOOD */
+    value++
+  }
+</script>
+
+<button on:click={handleClick}>Click Me</button>
+<input type="number" bind:value />
+
+{reactiveValue}

--- a/tests/fixtures/rules/no-reactive-reassign/valid/typeof01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-reassign/valid/typeof01-input.svelte
@@ -1,0 +1,10 @@
+<script>
+  let object = { value: 0 }
+  $: reactiveValue = { value: object.value * 2 }
+
+  function handleClick() {
+    console.log(typeof reactiveValue.value)
+  }
+</script>
+
+{reactiveValue}

--- a/tests/src/rules/no-reactive-reassign.ts
+++ b/tests/src/rules/no-reactive-reassign.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from "eslint"
+import rule from "../../../src/rules/no-reactive-reassign"
+import { loadTestCases } from "../../utils/utils"
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+})
+
+tester.run(
+  "no-reactive-reassign",
+  rule as any,
+  loadTestCases("no-reactive-reassign"),
+)


### PR DESCRIPTION
This PR adds `svelte/no-reactive-reassign` rule.

`svelte/no-reactive-reassign` rule that disallow reassigning reactive values.

e.g. 

```svelte
<script>
  /* eslint svelte/no-reactive-reassign: "error" */
  let value = 0
  $: reactiveValue = value * 2
  function handleClick() {
    /* ✓ GOOD */
    value++
    /* ✗ BAD */
    reactiveValue = value * 3
    reactiveValue++
  }
</script>
<!-- ✓ GOOD -->
<input type="number" bind:value />
<!-- ✗ BAD -->
<input type="number" bind:value={reactiveValue} />
```

