### PR TITLE
chore: add Node 20 in CI

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         eslint: [7, 8]
-        node: [14, 16, 17, 18]
+        node: [14, 16, 17, 18, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Svelte 4 branch also added CI with Node 20. So I added it to this repo also.