### PR TITLE
chore: introducing `@typescript-eslint/no-restricted-imports`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,24 @@ module.exports = {
       },
     },
     {
+      files: ["src/**"],
+      rules: {
+        "@typescript-eslint/no-restricted-imports": [
+          "error",
+          {
+            patterns: [
+              {
+                group: ["@typescript-eslint/*"],
+                message:
+                  "@typescript-eslint is not included in dependencies. Only type-import is allowed.",
+                allowTypeImports: true,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
       files: ["src/rules/**"],
       rules: {},
     },


### PR DESCRIPTION
This PR introduces `@typescript-eslint/no-restricted-imports`.
I have introduced #450 bugs in the past. I found a way to prevent this in the future by using `@typescript-eslint/no-restricted-imports`.

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-restricted-imports.md