### PR TITLE
fix: false positives for builtin `$$` vars in `svelte/prefer-destructured-store-props`

### DIFF
--- a/.changeset/gorgeous-geckos-unite.md
+++ b/.changeset/gorgeous-geckos-unite.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: false positives for builtin `$$` vars in `svelte/prefer-destructured-store-props`

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -157,7 +157,7 @@ export default createRule("prefer-destructured-store-props", {
       // $: ({ bar } = $foo);
       // {bar}
       // Same with {$foo["bar"]}
-      "MemberExpression[object.type='Identifier'][object.name=/^\\$/]"(
+      "MemberExpression[object.type='Identifier'][object.name=/^\\$[^\\$]/]"(
         node: StoreMemberExpression,
       ) {
         if (inScriptElement) return // Within a script tag
@@ -166,7 +166,7 @@ export default createRule("prefer-destructured-store-props", {
       Identifier(node: TSESTree.Identifier) {
         storeMemberAccessStack[0]?.identifiers.push(node)
       },
-      "MemberExpression[object.type='Identifier'][object.name=/^\\$/]:exit"(
+      "MemberExpression[object.type='Identifier'][object.name=/^\\$[^\\$]/]:exit"(
         node: StoreMemberExpression,
       ) {
         if (storeMemberAccessStack[0]?.node !== node) return

--- a/tests/fixtures/rules/prefer-destructured-store-props/valid/builtin-vars01-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/valid/builtin-vars01-input.svelte
@@ -1,0 +1,7 @@
+<div>
+  <slot name="title" />
+  {#if $$slots.description}
+    <hr />
+    <slot name="description" />
+  {/if}
+</div>

--- a/tests/fixtures/rules/prefer-destructured-store-props/valid/builtin-vars02-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/valid/builtin-vars02-input.svelte
@@ -1,0 +1,2 @@
+<Widget prop={$$props.prop} />
+<input type={$$restProps.type} />


### PR DESCRIPTION
related  to #463