### PR TITLE
chore: remove `require-jsdoc` internal rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     "plugin:@ota-meshi/+prettier",
   ],
   rules: {
-    "require-jsdoc": "error",
+    "require-jsdoc": "off",
     "no-warning-comments": "warn",
     "no-lonely-if": "off",
     "new-cap": "off",
@@ -150,7 +150,6 @@ module.exports = {
         project: require.resolve("./tsconfig.json"),
       },
       rules: {
-        "require-jsdoc": "off",
         "no-console": "off",
       },
     },

--- a/tools/render-rules.ts
+++ b/tools/render-rules.ts
@@ -44,13 +44,11 @@ const categoryRules = categories.map((cat) => {
   }
 })
 
-//eslint-disable-next-line require-jsdoc -- ignore
 export default function renderRulesTableContent(
   buildRulePath = (ruleName: string) => `./rules/${ruleName}.md`,
 ): string {
   // -----------------------------------------------------------------------------
 
-  //eslint-disable-next-line require-jsdoc -- ignore
   function toRuleRow(rule: RuleModule) {
     const mark = `${rule.meta.docs.recommended ? ":star:" : ""}${
       rule.meta.fixable ? ":wrench:" : ""
@@ -65,7 +63,6 @@ export default function renderRulesTableContent(
     return `| ${link} | ${description} | ${mark} |`
   }
 
-  //eslint-disable-next-line require-jsdoc -- ignore
   function toDeprecatedRuleRow(rule: RuleModule) {
     const link = `[${rule.meta.docs.ruleId}](${buildRulePath(
       rule.meta.docs.ruleName || "",

--- a/tools/update-docs.ts
+++ b/tools/update-docs.ts
@@ -4,7 +4,6 @@ import { rules } from "../src/utils/rules"
 import type { RuleModule } from "../src/types"
 import { getNewVersion } from "./lib/changesets-util"
 
-//eslint-disable-next-line require-jsdoc -- tools
 function formatItems(items: string[]) {
   if (items.length <= 2) {
     return items.join(" and ")
@@ -14,7 +13,6 @@ function formatItems(items: string[]) {
   }`
 }
 
-//eslint-disable-next-line require-jsdoc -- tools
 function yamlValue(val: unknown) {
   if (typeof val === "string") {
     return `"${val.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"')}"`
@@ -24,7 +22,6 @@ function yamlValue(val: unknown) {
 
 const ROOT = path.resolve(__dirname, "../docs/rules")
 
-//eslint-disable-next-line require-jsdoc -- tools
 function pickSince(content: string): string | null | Promise<string> {
   const fileIntro = /^---\n((?:.*\n)+)---\n*/.exec(content)
   if (fileIntro) {


### PR DESCRIPTION
In my experience in this repository, I felt that in most cases I have to write comments what is known by the function name too, so I thought it would be okay to remove this rule.