### PR TITLE
feat(block-lang): Added support for multiple modules of the same type

### DIFF
--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/_config.json
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/_config.json
@@ -1,0 +1,3 @@
+{
+  "options": [{ "script": ["ts"], "style": ["ts", null] }]
+}

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-errors.yaml
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-errors.yaml
@@ -1,0 +1,4 @@
+- message: The lang attribute of the <script> block should be "ts".
+  line: 1
+  column: 1
+  suggestions: null

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-input.svelte
@@ -1,0 +1,1 @@
+<script context="module" lang="javascript"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-input.svelte
@@ -1,2 +1,3 @@
 <script context="module" lang="javascript"></script>
+
 <script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/javascript01-input.svelte
@@ -1,1 +1,2 @@
 <script context="module" lang="javascript"></script>
+<script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-errors.yaml
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-errors.yaml
@@ -1,0 +1,4 @@
+- message: The lang attribute of the <script> block should be "ts".
+  line: 1
+  column: 1
+  suggestions: null

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-input.svelte
@@ -1,1 +1,2 @@
 <script context="module" lang="js"></script>
+<script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-input.svelte
@@ -1,0 +1,1 @@
+<script context="module" lang="js"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/js01-input.svelte
@@ -1,2 +1,3 @@
 <script context="module" lang="js"></script>
+
 <script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-errors.yaml
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-errors.yaml
@@ -1,0 +1,4 @@
+- message: The lang attribute of the <script> block should be "ts".
+  line: 1
+  column: 1
+  suggestions: null

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-input.svelte
@@ -1,2 +1,3 @@
 <script context="module"></script>
+
 <script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-input.svelte
@@ -1,0 +1,1 @@
+<script context="module"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/null01-input.svelte
@@ -1,1 +1,2 @@
 <script context="module"></script>
+<script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-errors.yaml
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-errors.yaml
@@ -1,0 +1,4 @@
+- message: The lang attribute of the <script> block should be "ts".
+  line: 1
+  column: 1
+  suggestions: null

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-input.svelte
@@ -1,3 +1,4 @@
 <script context="module"></script>
+<script lang="ts"></script>
 
 <style lang="ts"></style>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-input.svelte
@@ -1,0 +1,3 @@
+<script context="module"></script>
+
+<style lang="ts"></style>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/ts-as-style-lang01-input.svelte
@@ -1,4 +1,5 @@
 <script context="module"></script>
+
 <script lang="ts"></script>
 
 <style lang="ts"></style>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-errors.yaml
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-errors.yaml
@@ -1,0 +1,4 @@
+- message: The lang attribute of the <script> block should be "ts".
+  line: 1
+  column: 1
+  suggestions: null

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-input.svelte
@@ -1,1 +1,2 @@
 <script context="module" lang="typescript"></script>
+<script lang="ts"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-input.svelte
@@ -1,0 +1,1 @@
+<script context="module" lang="typescript"></script>

--- a/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-input.svelte
+++ b/tests/fixtures/rules/block-lang/invalid/script/module-context/typescript01-input.svelte
@@ -1,2 +1,3 @@
 <script context="module" lang="typescript"></script>
+
 <script lang="ts"></script>


### PR DESCRIPTION
Closes #507 

- [ ] The `enforcePresent` option doesn't fail when there's only a `context="module" block present` (it checks for the presence of any block) - should it?