### PR TITLE
fix: crash with non svelte files in `svelte/no-unused-class-name`

### DIFF
--- a/.changeset/tasty-flies-love.md
+++ b/.changeset/tasty-flies-love.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: crash with non svelte files in `svelte/no-unused-class-name`

--- a/src/rules/no-unused-class-name.ts
+++ b/src/rules/no-unused-class-name.ts
@@ -27,6 +27,9 @@ export default createRule("no-unused-class-name", {
     type: "suggestion",
   },
   create(context) {
+    if (!context.parserServices.isSvelte) {
+      return {}
+    }
     const classesUsedInTemplate: Record<string, SourceLocation> = {}
 
     return {

--- a/tests/fixtures/rules/no-unused-class-name/valid/test-input.js
+++ b/tests/fixtures/rules/no-unused-class-name/valid/test-input.js
@@ -1,0 +1,1 @@
+console.log("a")


### PR DESCRIPTION
fixes #512