### PR TITLE
fix: handle type aliases for $$Slots and $$Events related rules

### DIFF
--- a/.changeset/light-boats-press.md
+++ b/.changeset/light-boats-press.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: handle type aliases for $$Events and $$Slots declarations

--- a/src/rules/experimental-require-slot-types.ts
+++ b/src/rules/experimental-require-slot-types.ts
@@ -1,6 +1,8 @@
 import { createRule } from "../utils"
 import { getLangValue } from "../utils/ast-utils"
 
+const SLOTS_TYPE_NAME = "$$Slots"
+
 export default createRule("experimental-require-slot-types", {
   meta: {
     docs: {
@@ -18,7 +20,7 @@ export default createRule("experimental-require-slot-types", {
   create(context) {
     let isTs = false
     let hasSlot = false
-    let hasInterface = false
+    let hasDeclaredSlots = false
     return {
       SvelteScriptElement(node) {
         const lang = getLangValue(node)?.toLowerCase()
@@ -30,12 +32,17 @@ export default createRule("experimental-require-slot-types", {
         }
       },
       TSInterfaceDeclaration(node) {
-        if (node.id.name === "$$Slots") {
-          hasInterface = true
+        if (node.id.name === SLOTS_TYPE_NAME) {
+          hasDeclaredSlots = true
+        }
+      },
+      TSTypeAliasDeclaration(node) {
+        if (node.id.name === SLOTS_TYPE_NAME) {
+          hasDeclaredSlots = true
         }
       },
       "Program:exit"() {
-        if (isTs && hasSlot && !hasInterface) {
+        if (isTs && hasSlot && !hasDeclaredSlots) {
           context.report({
             loc: {
               line: 1,

--- a/tests/fixtures/rules/experimental-require-slot-types/valid/has-slot-types-with-alias01-input.svelte
+++ b/tests/fixtures/rules/experimental-require-slot-types/valid/has-slot-types-with-alias01-input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  type $$Slots = {
+    defalt: Record<string, never>
+  }
+</script>
+
+<slot />

--- a/tests/fixtures/rules/experimental-require-strict-events/valid/has-events-type-alias01-input.svelte
+++ b/tests/fixtures/rules/experimental-require-strict-events/valid/has-events-type-alias01-input.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+  type $$Events = {}
+</script>


### PR DESCRIPTION
Hello 👋

Currently these two rules `experimental-require-strict-events`, `experimental-require-slot-types` which assert existence of $$Slots/$$Events handles interface declarations only. However, Svelte Language Server works with type aliases as well. I added an option that will catch them when they're declared as type aliases. I also added failing tests, before implementing fixes. 

I'm also wondering whether the wording e.g. `The component must define the $$Slots interface` should be adjusted? 

Closes #528 
