### PR TITLE
docs: update README to use Svelte style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module.exports = {
   extends: [
     // add more generic rule sets here, such as:
     // 'eslint:recommended',
-    "plugin:svelte/recommended",
+    'plugin:svelte/recommended',
   ],
   rules: {
     // override/add rules settings here, such as:
@@ -93,8 +93,8 @@ The `eslint-plugin-svelte` can not be used with the [eslint-plugin-svelte3].
 If you are using [eslint-plugin-svelte3] you need to remove it.
 
 ```diff
-  "plugins": [
--   "svelte3"
+  plugins: [
+-   'svelte3'
   ]
 ```
 
@@ -104,19 +104,19 @@ If you are using [eslint-plugin-svelte3] you need to remove it.
 
 If you have specified a parser, you need to configure a parser for `.svelte`.
 
-For example, if you are using the `"@babel/eslint-parser"`, configure it as follows:
+For example, if you are using `@babel/eslint-parser`, configure it as follows:
 
 ```js
 module.exports = {
   // ...
-  extends: ["plugin:svelte/recommended"],
+  extends: ['plugin:svelte/recommended'],
   // ...
-  parser: "@babel/eslint-parser",
+  parser: '@babel/eslint-parser',
   // Add an `overrides` section to add a parser configuration for svelte.
   overrides: [
     {
-      files: ["*.svelte"],
-      parser: "svelte-eslint-parser",
+      files: ['*.svelte'],
+      parser: 'svelte-eslint-parser',
     },
     // ...
   ],
@@ -124,26 +124,26 @@ module.exports = {
 }
 ```
 
-For example, if you are using the `"@typescript-eslint/parser"`, and if you want to use TypeScript in `<script>` of `.svelte`, you need to add more `parserOptions` configuration.
+For example, if you are using `@typescript-eslint/parser`, and if you want to use TypeScript in `<script>` of `.svelte`, you need to add more `parserOptions` configuration.
 
 ```js
 module.exports = {
   // ...
-  extends: ["plugin:svelte/recommended"],
+  extends: ['plugin:svelte/recommended'],
   // ...
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     // ...
-    project: "path/to/your/tsconfig.json",
-    extraFileExtensions: [".svelte"], // This is a required setting in `@typescript-eslint/parser` v4.24.0.
+    project: 'path/to/your/tsconfig.json',
+    extraFileExtensions: ['.svelte'], // This is a required setting in `@typescript-eslint/parser` v4.24.0.
   },
   overrides: [
     {
-      files: ["*.svelte"],
-      parser: "svelte-eslint-parser",
+      files: ['*.svelte'],
+      parser: 'svelte-eslint-parser',
       // Parse the `<script>` in `.svelte` as TypeScript by adding the following configuration.
       parserOptions: {
-        parser: "@typescript-eslint/parser",
+        parser: '@typescript-eslint/parser',
       },
     },
     // ...
@@ -159,14 +159,14 @@ module.exports = {
   // ...
   overrides: [
     {
-      files: ["*.svelte"],
-      parser: "svelte-eslint-parser",
+      files: ['*.svelte'],
+      parser: 'svelte-eslint-parser',
       parserOptions: {
         parser: {
           // Specify a parser for each lang.
-          ts: "@typescript-eslint/parser",
-          js: "espree",
-          typescript: "@typescript-eslint/parser",
+          ts: '@typescript-eslint/parser',
+          js: 'espree',
+          typescript: '@typescript-eslint/parser',
         },
       },
     },
@@ -201,17 +201,17 @@ module.exports = {
   settings: {
     svelte: {
       ignoreWarnings: [
-        "@typescript-eslint/no-unsafe-assignment",
-        "@typescript-eslint/no-unsafe-member-access",
+        '@typescript-eslint/no-unsafe-assignment',
+        '@typescript-eslint/no-unsafe-member-access',
       ],
       compileOptions: {
         postcss: {
-          configFilePath: "./path/to/my/postcss.config.js",
+          configFilePath: './path/to/my/postcss.config.js',
         },
       },
       kit: {
         files: {
-          routes: "src/routes",
+          routes: 'src/routes',
         },
       },
     },
@@ -247,7 +247,7 @@ module.exports = {
     svelte: {
       kit: {
         files: {
-          routes: "src/routes",
+          routes: 'src/routes',
         },
       },
     },
@@ -264,7 +264,7 @@ Examples:
 
 ```bash
 eslint --ext .js,.svelte src
-eslint "src/**/*.{js,svelte}"
+eslint 'src/**/*.{js,svelte}'
 ```
 
 ## :computer: Editor Integrations


### PR DESCRIPTION
Projects in the Svelte org use single quotes for JavaScript strings and our new project creation wizards like `npm init svelte` use single quotes for JavaScript strings as well. Using single quotes in the README would make it a lot easier to setup this plugin because I could copy/paste the code from the README into a project without having to update the formatting.