### PR TITLE
fix: replace deprecated typeParameters with typeArguments

### DIFF
--- a/.changeset/small-fishes-sin.md
+++ b/.changeset/small-fishes-sin.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: replace deprecated typeParameters with typeArguments

--- a/src/rules/indent-helpers/es.ts
+++ b/src/rules/indent-helpers/es.ts
@@ -183,19 +183,20 @@ export function defineVisitor(context: IndentContext): NodeListener {
 			visitor.BreakStatement(node);
 		},
 		CallExpression(node: TSESTree.CallExpression) {
+			const typeArguments = node.typeArguments ?? node.typeParameters;
 			const firstToken = sourceCode.getFirstToken(node);
-			const leftParenToken = sourceCode.getTokenAfter(node.typeParameters || node.callee, {
+			const leftParenToken = sourceCode.getTokenAfter(typeArguments || node.callee, {
 				filter: isOpeningParenToken,
 				includeComments: false
 			})!;
 			const rightParenToken = sourceCode.getLastToken(node);
 
-			if (node.typeParameters) {
-				offsets.setOffsetToken(sourceCode.getFirstToken(node.typeParameters), 1, firstToken);
+			if (typeArguments) {
+				offsets.setOffsetToken(sourceCode.getFirstToken(typeArguments), 1, firstToken);
 			}
 
 			for (const optionalToken of sourceCode.getTokensBetween(
-				sourceCode.getLastToken(node.typeParameters || node.callee),
+				sourceCode.getLastToken(typeArguments || node.callee),
 				leftParenToken,
 				{ filter: isOptionalToken, includeComments: false }
 			)) {
@@ -693,18 +694,15 @@ export function defineVisitor(context: IndentContext): NodeListener {
 			visitor.MethodDefinition(node);
 		},
 		NewExpression(node: TSESTree.NewExpression) {
+			const typeArguments = node.typeArguments ?? node.typeParameters;
 			const newToken = sourceCode.getFirstToken(node);
 			const calleeTokens = getFirstAndLastTokens(sourceCode, node.callee);
 			offsets.setOffsetToken(calleeTokens.firstToken, 1, newToken);
 
-			if (node.typeParameters) {
-				offsets.setOffsetToken(
-					sourceCode.getFirstToken(node.typeParameters),
-					1,
-					calleeTokens.firstToken
-				);
+			if (typeArguments) {
+				offsets.setOffsetToken(sourceCode.getFirstToken(typeArguments), 1, calleeTokens.firstToken);
 			}
-			const leftParenBefore = node.typeParameters || calleeTokens.lastToken;
+			const leftParenBefore = typeArguments || calleeTokens.lastToken;
 			if (node.arguments.length || leftParenBefore.range[1] < node.range[1]) {
 				const rightParenToken = sourceCode.getLastToken(node);
 				const leftParenToken = sourceCode.getTokenAfter(leftParenBefore)!;

--- a/src/rules/indent-helpers/ts.ts
+++ b/src/rules/indent-helpers/ts.ts
@@ -62,9 +62,10 @@ export function defineVisitor(context: IndentContext): NodeListener {
 			// or
 			// const ErrorMap = Map<string, Error>
 			//                  ^^^^^^^^^^^^^^^^^^
-			if (node.typeParameters) {
+			const typeArguments = node.typeArguments ?? node.typeParameters;
+			if (typeArguments) {
 				const firstToken = sourceCode.getFirstToken(node);
-				offsets.setOffsetToken(sourceCode.getFirstToken(node.typeParameters), 1, firstToken);
+				offsets.setOffsetToken(sourceCode.getFirstToken(typeArguments), 1, firstToken);
 			}
 		},
 		TSInstantiationExpression(node: TSESTree.TSInstantiationExpression) {
@@ -401,9 +402,10 @@ export function defineVisitor(context: IndentContext): NodeListener {
 		TSClassImplements(node: TSESTree.TSClassImplements | TSESTree.TSInterfaceHeritage) {
 			// class C implements T {}
 			//                    ^
-			if (node.typeParameters) {
+			const typeArguments = node.typeArguments ?? node.typeParameters;
+			if (typeArguments) {
 				offsets.setOffsetToken(
-					sourceCode.getFirstToken(node.typeParameters),
+					sourceCode.getFirstToken(typeArguments),
 					1,
 					sourceCode.getFirstToken(node)
 				);
@@ -675,6 +677,7 @@ export function defineVisitor(context: IndentContext): NodeListener {
 		},
 		TSImportType(node: TSESTree.TSImportType) {
 			// import('foo').B
+			const typeArguments = node.typeArguments ?? node.typeParameters;
 			const firstToken = sourceCode.getFirstToken(node);
 			const leftParenToken = sourceCode.getTokenAfter(firstToken, {
 				filter: isOpeningParenToken,
@@ -695,8 +698,8 @@ export function defineVisitor(context: IndentContext): NodeListener {
 				const propertyToken = sourceCode.getTokenAfter(dotToken);
 				offsets.setOffsetToken([dotToken, propertyToken], 1, firstToken);
 			}
-			if (node.typeParameters) {
-				offsets.setOffsetToken(sourceCode.getFirstToken(node.typeParameters), 1, firstToken);
+			if (typeArguments) {
+				offsets.setOffsetToken(sourceCode.getFirstToken(typeArguments), 1, firstToken);
 			}
 		},
 		TSParameterProperty(node: TSESTree.TSParameterProperty) {
@@ -1055,9 +1058,10 @@ export function defineVisitor(context: IndentContext): NodeListener {
 					sourceCode.getFirstToken(node.id || node)
 				);
 			}
-			if (node.superTypeParameters != null && node.superClass != null) {
+			const superTypeArguments = node.superTypeArguments ?? node.superTypeParameters;
+			if (superTypeArguments != null && node.superClass != null) {
 				offsets.setOffsetToken(
-					sourceCode.getFirstToken(node.superTypeParameters),
+					sourceCode.getFirstToken(superTypeArguments),
 					1,
 					sourceCode.getFirstToken(node.superClass)
 				);

--- a/src/rules/require-event-dispatcher-types.ts
+++ b/src/rules/require-event-dispatcher-types.ts
@@ -42,7 +42,7 @@ export default createRule('require-event-dispatcher-types', {
 					}
 				})) {
 					const node = n as TSESTree.CallExpression;
-					if (node.typeParameters === undefined) {
+					if ((node.typeArguments ?? node.typeParameters) === undefined) {
 						context.report({ node, messageId: 'missingTypeParameter' });
 					}
 				}


### PR DESCRIPTION
This PR replaces the deprecated typeParameters with typeArguments.
It appears that some node typeParameters have been deprecated. But to support older parsers, we want to use typeParameters if typeArguments doesn't exist.