### PR TITLE
docs: clarify docs for `svelte/no-target-blank`

### DIFF
--- a/docs/rules/no-target-blank.md
+++ b/docs/rules/no-target-blank.md
@@ -46,8 +46,8 @@ This rule disallows using `target="_blank"` attribute without `rel="noopener nor
 }
 ```
 
-- `allowReferrer` ... If `true`, does not require noreferrer.default `false`
-- `enforceDynamicLinks ("always" | "never")` ... If `always`, enforces the rule if the href is a dynamic link. default `always`.
+- `allowReferrer` ... If `true`, allows the `Referrer` header to be sent by not requiring `noreferrer` to be present. default `false`
+- `enforceDynamicLinks ("always" | "never")` ... If `always`, enforces the rule if the href is a dynamic link. default `always`
 
 ### `{ allowReferrer: false }` (default)
 

--- a/docs/rules/no-target-blank.md
+++ b/docs/rules/no-target-blank.md
@@ -12,7 +12,7 @@ since: 'v0.0.4'
 
 ## :book: Rule Details
 
-This rule disallows using `target="_blank"` attribute without `rel="noopener noreferrer"` to avoid a security vulnerability in legacy browsers ([see here for more details](https://mathiasbynens.github.io/rel-noopener/)).
+This rule disallows using `target="_blank"` attribute without `rel="noopener noreferrer"` to avoid a security vulnerability in legacy browsers where a page can trigger a navigation in the opener regardless of origin ([see here for more details](https://mathiasbynens.github.io/rel-noopener/)).
 
 <ESLintCodeBlock>
 

--- a/docs/rules/no-target-blank.md
+++ b/docs/rules/no-target-blank.md
@@ -12,7 +12,7 @@ since: 'v0.0.4'
 
 ## :book: Rule Details
 
-This rule disallows using `target="_blank"` attribute without `rel="noopener noreferrer"` to avoid a security vulnerability([see here for more details](https://mathiasbynens.github.io/rel-noopener/)).
+This rule disallows using `target="_blank"` attribute without `rel="noopener noreferrer"` to avoid a security vulnerability in legacy browsers ([see here for more details](https://mathiasbynens.github.io/rel-noopener/)).
 
 <ESLintCodeBlock>
 


### PR DESCRIPTION
The behavior of `allowReferrer` was very confusing to me because I thought it was referring to the `rel` attribute and I did not understand it's actually referring to the `Referer` header being allowed

I was also very confused about the security vulnerability being referred to. I assumed it was related to protecting the user's privacy by not passing the referrer header. When I happened to click the reference link I saw that I had been misunderstanding the purpose of this rule and what exactly it was doing.