### PR TITLE
Update svelte-eslint-parser version syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "postcss-safe-parser": "^6.0.0",
     "postcss-selector-parser": "^6.0.15",
     "semver": "^7.6.0",
-    "svelte-eslint-parser": ">=0.34.0-next.12 <1.0.0"
+    "svelte-eslint-parser": "^0.34.0-next.12"
   },
   "devDependencies": {
     "@1stg/browserslist-config": "^2.0.0",


### PR DESCRIPTION
Use a simplified version syntax for the `svelte-eslint-parser` dependency so that `bun` can install properly - otherwise it fails with the following error:
```shell
bun i
bun install v1.0.26 (c75e768a)
warn: incorrect peer dependency "svelte@5.0.0-next.80"

error: No version matching ">=0.34.0-next.12 <1.0.0" found for specifier "svelte-eslint-parser" (but package exists)
```