### PR TITLE
feat: Follow latest Svelte 5

### DIFF
--- a/.changeset/lazy-dancers-vanish.md
+++ b/.changeset/lazy-dancers-vanish.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": minor
+---
+
+Use the latest Svelte 5

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0-0 || ^9.0.0-0",
-    "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.95"
+    "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.112"
   },
   "peerDependenciesMeta": {
     "svelte": {
@@ -169,7 +169,7 @@
     "stylelint": "~16.3.1",
     "stylelint-config-standard": "^36.0.0",
     "stylus": "^0.63.0",
-    "svelte": "^5.0.0-next.108",
+    "svelte": "^5.0.0-next.112",
     "svelte-adapter-ghpages": "0.2.2",
     "svelte-i18n": "^4.0.0",
     "tslib": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "postcss-safe-parser": "^6.0.0",
     "postcss-selector-parser": "^6.0.16",
     "semver": "^7.6.0",
-    "svelte-eslint-parser": ">=0.34.0 <1.0.0"
+    "svelte-eslint-parser": ">=0.35.0 <1.0.0"
   },
   "devDependencies": {
     "@1stg/browserslist-config": "^2.0.0",


### PR DESCRIPTION
Use the latest Svelte 5 compatible parser.

Should we increase the minor version for this change?