### PR TITLE
fix: disable a few rules in docs-svelte-kit

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,7 +129,9 @@ const config = [
 		rules: {
 			'n/file-extension-in-import': 'off',
 			'n/no-unsupported-features/es-syntax': 'off',
-			'n/no-unsupported-features/es-builtins': 'off'
+			'n/no-unsupported-features/es-builtins': 'off',
+			'n/no-unsupported-features/node-builtins': 'off',
+			'n/no-missing-import': 'off'
 		}
 	},
 	{


### PR DESCRIPTION
I have no idea how to fix below lint errors.
https://github.com/sveltejs/eslint-plugin-svelte/actions/runs/8978756715/job/24659835714

So I just disable rules.