### PR TITLE
fix: false positives for import vars with TS in `svelte/valid-compile`

### DIFF
--- a/.changeset/ninety-lobsters-dress.md
+++ b/.changeset/ninety-lobsters-dress.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: false positives for import vars with TS in `svelte/valid-compile`

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
@@ -35,7 +35,8 @@ export function transform(
 					ts.ScriptTarget.ESNext,
 				module: ts.ModuleKind.ESNext,
 				importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Preserve,
-				sourceMap: true
+				sourceMap: true,
+				preserveValueImports: true
 			}
 		});
 

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
@@ -35,8 +35,8 @@ export function transform(
 					ts.ScriptTarget.ESNext,
 				module: ts.ModuleKind.ESNext,
 				importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Preserve,
-				sourceMap: true,
-				preserveValueImports: true
+				preserveValueImports: true,
+				sourceMap: true
 			}
 		});
 

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-compile/valid/ts/ts-unused-in-script-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-compile/valid/ts/ts-unused-in-script-input.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+</script>
+
+{$page}


### PR DESCRIPTION

close #652

This PR fixes the issue mentioned in the comments below.

https://github.com/sveltejs/eslint-plugin-svelte/issues/652#issuecomment-2087008855

In the code posted at the top of the thread the rule seems to work correctly, and correctly shows the svelte compiler warnings.