### PR TITLE
fix: `svelte/valid-compile` to use verbatimModuleSyntax to work with TS v5.5.

### DIFF
--- a/.changeset/tough-jobs-rest.md
+++ b/.changeset/tough-jobs-rest.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: `svelte/valid-compile` to use verbatimModuleSyntax to work with TS v5.5.

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
@@ -36,6 +36,7 @@ export function transform(
 				module: ts.ModuleKind.ESNext,
 				importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Preserve,
 				preserveValueImports: true,
+				verbatimModuleSyntax: true,
 				sourceMap: true
 			}
 		});


### PR DESCRIPTION
See comment https://github.com/sveltejs/eslint-plugin-svelte/pull/790#discussion_r1642834898