### PR TITLE
docs: fix links

### DIFF
--- a/docs/rules/@typescript-eslint/no-unnecessary-condition.md
+++ b/docs/rules/@typescript-eslint/no-unnecessary-condition.md
@@ -69,7 +69,7 @@ This rule was introduced in eslint-plugin-svelte v2.9.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/@typescript-eslint/no-unnecessary-condition.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/@typescript-eslint/no-unnecessary-condition.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/@typescript-eslint/no-unnecessary-condition.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/@typescript-eslint/no-unnecessary-condition.ts)
 
 <sup>Taken with ❤️ [from @typescript-eslint/eslint-plugin](https://typescript-eslint.io/rules/no-unnecessary-condition/)</sup>

--- a/docs/rules/block-lang.md
+++ b/docs/rules/block-lang.md
@@ -83,5 +83,5 @@ This rule was introduced in eslint-plugin-svelte v2.18.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/block-lang.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/block-lang.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/block-lang.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/block-lang.ts)

--- a/docs/rules/button-has-type.md
+++ b/docs/rules/button-has-type.md
@@ -67,5 +67,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.4
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/button-has-type.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/button-has-type.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/button-has-type.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/button-has-type.ts)

--- a/docs/rules/comment-directive.md
+++ b/docs/rules/comment-directive.md
@@ -112,5 +112,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.13
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/comment-directive.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/comment-directive.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/comment-directive.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/comment-directive.ts)

--- a/docs/rules/derived-has-same-inputs-outputs.md
+++ b/docs/rules/derived-has-same-inputs-outputs.md
@@ -51,5 +51,5 @@ This rule was introduced in eslint-plugin-svelte v2.8.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/derived-has-same-inputs-outputs.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/derived-has-same-inputs-outputs.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/derived-has-same-inputs-outputs.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/derived-has-same-inputs-outputs.ts)

--- a/docs/rules/experimental-require-slot-types.md
+++ b/docs/rules/experimental-require-slot-types.md
@@ -112,5 +112,5 @@ This rule was introduced in eslint-plugin-svelte v2.18.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/experimental-require-slot-types.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/experimental-require-slot-types.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/experimental-require-slot-types.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/experimental-require-slot-types.ts)

--- a/docs/rules/experimental-require-strict-events.md
+++ b/docs/rules/experimental-require-strict-events.md
@@ -64,5 +64,5 @@ This rule was introduced in eslint-plugin-svelte v2.18.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/experimental-require-strict-events.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/experimental-require-strict-events.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/experimental-require-strict-events.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/experimental-require-strict-events.ts)

--- a/docs/rules/first-attribute-linebreak.md
+++ b/docs/rules/first-attribute-linebreak.md
@@ -80,5 +80,5 @@ This rule was introduced in eslint-plugin-svelte v0.6.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/first-attribute-linebreak.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/first-attribute-linebreak.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/first-attribute-linebreak.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/first-attribute-linebreak.ts)

--- a/docs/rules/html-closing-bracket-spacing.md
+++ b/docs/rules/html-closing-bracket-spacing.md
@@ -78,5 +78,5 @@ This rule was introduced in eslint-plugin-svelte v2.3.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/html-closing-bracket-spacing.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/html-closing-bracket-spacing.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/html-closing-bracket-spacing.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/html-closing-bracket-spacing.ts)

--- a/docs/rules/html-quotes.md
+++ b/docs/rules/html-quotes.md
@@ -73,5 +73,5 @@ This rule was introduced in eslint-plugin-svelte v0.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/html-quotes.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/html-quotes.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/html-quotes.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/html-quotes.ts)

--- a/docs/rules/html-self-closing.md
+++ b/docs/rules/html-self-closing.md
@@ -102,5 +102,5 @@ This rule was introduced in eslint-plugin-svelte v2.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/html-self-closing.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/html-self-closing.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/html-self-closing.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/html-self-closing.ts)

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -99,5 +99,5 @@ This rule was introduced in eslint-plugin-svelte v0.3.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/indent.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/indent.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/indent.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/indent.ts)

--- a/docs/rules/infinite-reactive-loop.md
+++ b/docs/rules/infinite-reactive-loop.md
@@ -99,5 +99,5 @@ This rule was introduced in eslint-plugin-svelte v2.16.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/infinite-reactive-loop.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/infinite-reactive-loop.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/infinite-reactive-loop.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/infinite-reactive-loop.ts)

--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -88,5 +88,5 @@ This rule was introduced in eslint-plugin-svelte v0.2.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/max-attributes-per-line.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/max-attributes-per-line.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/max-attributes-per-line.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/max-attributes-per-line.ts)

--- a/docs/rules/mustache-spacing.md
+++ b/docs/rules/mustache-spacing.md
@@ -94,5 +94,5 @@ This rule was introduced in eslint-plugin-svelte v0.15.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/mustache-spacing.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/mustache-spacing.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/mustache-spacing.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/mustache-spacing.ts)

--- a/docs/rules/no-at-debug-tags.md
+++ b/docs/rules/no-at-debug-tags.md
@@ -49,5 +49,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.1
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-at-debug-tags.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-at-debug-tags.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-at-debug-tags.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-at-debug-tags.ts)

--- a/docs/rules/no-at-html-tags.md
+++ b/docs/rules/no-at-html-tags.md
@@ -52,5 +52,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.1
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-at-html-tags.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-at-html-tags.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-at-html-tags.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-at-html-tags.ts)

--- a/docs/rules/no-dom-manipulating.md
+++ b/docs/rules/no-dom-manipulating.md
@@ -104,5 +104,5 @@ This rule was introduced in eslint-plugin-svelte v2.13.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-dom-manipulating.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-dom-manipulating.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-dom-manipulating.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-dom-manipulating.ts)

--- a/docs/rules/no-dupe-else-if-blocks.md
+++ b/docs/rules/no-dupe-else-if-blocks.md
@@ -128,5 +128,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.1
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-dupe-else-if-blocks.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-dupe-else-if-blocks.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-dupe-else-if-blocks.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-dupe-else-if-blocks.ts)

--- a/docs/rules/no-dupe-on-directives.md
+++ b/docs/rules/no-dupe-on-directives.md
@@ -52,5 +52,5 @@ This rule was introduced in eslint-plugin-svelte v2.14.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-dupe-on-directives.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-dupe-on-directives.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-dupe-on-directives.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-dupe-on-directives.ts)

--- a/docs/rules/no-dupe-style-properties.md
+++ b/docs/rules/no-dupe-style-properties.md
@@ -47,5 +47,5 @@ This rule was introduced in eslint-plugin-svelte v0.31.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-dupe-style-properties.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-dupe-style-properties.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-dupe-style-properties.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-dupe-style-properties.ts)

--- a/docs/rules/no-dupe-use-directives.md
+++ b/docs/rules/no-dupe-use-directives.md
@@ -45,5 +45,5 @@ This rule was introduced in eslint-plugin-svelte v2.14.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-dupe-use-directives.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-dupe-use-directives.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-dupe-use-directives.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-dupe-use-directives.ts)

--- a/docs/rules/no-dynamic-slot-name.md
+++ b/docs/rules/no-dynamic-slot-name.md
@@ -49,5 +49,5 @@ This rule was introduced in eslint-plugin-svelte v0.14.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-dynamic-slot-name.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-dynamic-slot-name.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-dynamic-slot-name.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-dynamic-slot-name.ts)

--- a/docs/rules/no-export-load-in-svelte-module-in-kit-pages.md
+++ b/docs/rules/no-export-load-in-svelte-module-in-kit-pages.md
@@ -62,5 +62,5 @@ This rule was introduced in eslint-plugin-svelte v2.12.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-export-load-in-svelte-module-in-kit-pages.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-export-load-in-svelte-module-in-kit-pages.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-export-load-in-svelte-module-in-kit-pages.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-export-load-in-svelte-module-in-kit-pages.ts)

--- a/docs/rules/no-extra-reactive-curlies.md
+++ b/docs/rules/no-extra-reactive-curlies.md
@@ -53,5 +53,5 @@ This rule was introduced in eslint-plugin-svelte v2.4.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-extra-reactive-curlies.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-extra-reactive-curlies.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-extra-reactive-curlies.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-extra-reactive-curlies.ts)

--- a/docs/rules/no-goto-without-base.md
+++ b/docs/rules/no-goto-without-base.md
@@ -60,5 +60,5 @@ This rule was introduced in eslint-plugin-svelte v2.36.0-next.9
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-goto-without-base.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-goto-without-base.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-goto-without-base.ts)

--- a/docs/rules/no-ignored-unsubscribe.md
+++ b/docs/rules/no-ignored-unsubscribe.md
@@ -47,5 +47,5 @@ This rule was introduced in eslint-plugin-svelte v2.34.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-ignored-unsubscribe.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-ignored-unsubscribe.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-ignored-unsubscribe.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-ignored-unsubscribe.ts)

--- a/docs/rules/no-immutable-reactive-statements.md
+++ b/docs/rules/no-immutable-reactive-statements.md
@@ -66,5 +66,5 @@ This rule was introduced in eslint-plugin-svelte v2.27.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-immutable-reactive-statements.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-immutable-reactive-statements.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-immutable-reactive-statements.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-immutable-reactive-statements.ts)

--- a/docs/rules/no-inline-styles.md
+++ b/docs/rules/no-inline-styles.md
@@ -68,5 +68,5 @@ This rule was introduced in eslint-plugin-svelte v2.35.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-inline-styles.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-inline-styles.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-inline-styles.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-inline-styles.ts)

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -70,7 +70,7 @@ This rule was introduced in eslint-plugin-svelte v0.0.8
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-inner-declarations.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-inner-declarations.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-inner-declarations.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-inner-declarations.ts)
 
 <sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/no-inner-declarations)</sup>

--- a/docs/rules/no-not-function-handler.md
+++ b/docs/rules/no-not-function-handler.md
@@ -61,5 +61,5 @@ This rule was introduced in eslint-plugin-svelte v0.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-not-function-handler.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-not-function-handler.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-not-function-handler.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-not-function-handler.ts)

--- a/docs/rules/no-object-in-text-mustaches.md
+++ b/docs/rules/no-object-in-text-mustaches.md
@@ -54,5 +54,5 @@ This rule was introduced in eslint-plugin-svelte v0.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-object-in-text-mustaches.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-object-in-text-mustaches.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-object-in-text-mustaches.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-object-in-text-mustaches.ts)

--- a/docs/rules/no-reactive-functions.md
+++ b/docs/rules/no-reactive-functions.md
@@ -61,5 +61,5 @@ This rule was introduced in eslint-plugin-svelte v2.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-reactive-functions.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-reactive-functions.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-reactive-functions.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-reactive-functions.ts)

--- a/docs/rules/no-reactive-literals.md
+++ b/docs/rules/no-reactive-literals.md
@@ -50,5 +50,5 @@ This rule was introduced in eslint-plugin-svelte v2.4.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-reactive-literals.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-reactive-literals.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-reactive-literals.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-reactive-literals.ts)

--- a/docs/rules/no-reactive-reassign.md
+++ b/docs/rules/no-reactive-reassign.md
@@ -124,5 +124,5 @@ This rule was introduced in eslint-plugin-svelte v2.27.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-reactive-reassign.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-reactive-reassign.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-reactive-reassign.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-reactive-reassign.ts)

--- a/docs/rules/no-restricted-html-elements.md
+++ b/docs/rules/no-restricted-html-elements.md
@@ -98,5 +98,5 @@ This rule was introduced in eslint-plugin-svelte v2.31.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-restricted-html-elements.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-restricted-html-elements.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-restricted-html-elements.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-restricted-html-elements.ts)

--- a/docs/rules/no-shorthand-style-property-overrides.md
+++ b/docs/rules/no-shorthand-style-property-overrides.md
@@ -57,5 +57,5 @@ This rule was introduced in eslint-plugin-svelte v0.31.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-shorthand-style-property-overrides.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-shorthand-style-property-overrides.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-shorthand-style-property-overrides.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-shorthand-style-property-overrides.ts)

--- a/docs/rules/no-spaces-around-equal-signs-in-attribute.md
+++ b/docs/rules/no-spaces-around-equal-signs-in-attribute.md
@@ -53,5 +53,5 @@ This rule was introduced in eslint-plugin-svelte v2.3.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-spaces-around-equal-signs-in-attribute.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-spaces-around-equal-signs-in-attribute.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-spaces-around-equal-signs-in-attribute.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-spaces-around-equal-signs-in-attribute.ts)

--- a/docs/rules/no-store-async.md
+++ b/docs/rules/no-store-async.md
@@ -51,5 +51,5 @@ This rule was introduced in eslint-plugin-svelte v2.7.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-store-async.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-store-async.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-store-async.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-store-async.ts)

--- a/docs/rules/no-svelte-internal.md
+++ b/docs/rules/no-svelte-internal.md
@@ -54,5 +54,5 @@ This rule was introduced in eslint-plugin-svelte v2.39.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-svelte-internal.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-svelte-internal.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-svelte-internal.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-svelte-internal.ts)

--- a/docs/rules/no-target-blank.md
+++ b/docs/rules/no-target-blank.md
@@ -135,5 +135,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.4
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-target-blank.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-target-blank.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-target-blank.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-target-blank.ts)

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -81,7 +81,7 @@ This rule was introduced in eslint-plugin-svelte v2.7.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-trailing-spaces.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-trailing-spaces.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-trailing-spaces.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-trailing-spaces.ts)
 
 <sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/no-trailing-spaces)</sup>

--- a/docs/rules/no-unknown-style-directive-property.md
+++ b/docs/rules/no-unknown-style-directive-property.md
@@ -71,5 +71,5 @@ This rule was introduced in eslint-plugin-svelte v0.31.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-unknown-style-directive-property.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-unknown-style-directive-property.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-unknown-style-directive-property.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-unknown-style-directive-property.ts)

--- a/docs/rules/no-unused-class-name.md
+++ b/docs/rules/no-unused-class-name.md
@@ -71,5 +71,5 @@ This rule was introduced in eslint-plugin-svelte v2.31.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-unused-class-name.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-unused-class-name.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-unused-class-name.ts)

--- a/docs/rules/no-unused-svelte-ignore.md
+++ b/docs/rules/no-unused-svelte-ignore.md
@@ -50,5 +50,5 @@ This rule was introduced in eslint-plugin-svelte v0.19.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-unused-svelte-ignore.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-unused-svelte-ignore.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-unused-svelte-ignore.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-unused-svelte-ignore.ts)

--- a/docs/rules/no-useless-mustaches.md
+++ b/docs/rules/no-useless-mustaches.md
@@ -97,5 +97,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.4
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/no-useless-mustaches.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/no-useless-mustaches.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/no-useless-mustaches.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/no-useless-mustaches.ts)

--- a/docs/rules/prefer-class-directive.md
+++ b/docs/rules/prefer-class-directive.md
@@ -74,5 +74,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.1
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/prefer-class-directive.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/prefer-class-directive.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/prefer-class-directive.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/prefer-class-directive.ts)

--- a/docs/rules/prefer-destructured-store-props.md
+++ b/docs/rules/prefer-destructured-store-props.md
@@ -55,5 +55,5 @@ This rule was introduced in eslint-plugin-svelte v2.10.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/prefer-destructured-store-props.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/prefer-destructured-store-props.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/prefer-destructured-store-props.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/prefer-destructured-store-props.ts)

--- a/docs/rules/prefer-style-directive.md
+++ b/docs/rules/prefer-style-directive.md
@@ -77,5 +77,5 @@ This rule was introduced in eslint-plugin-svelte v0.22.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/prefer-style-directive.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/prefer-style-directive.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/prefer-style-directive.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/prefer-style-directive.ts)

--- a/docs/rules/require-each-key.md
+++ b/docs/rules/require-each-key.md
@@ -54,5 +54,5 @@ This rule was introduced in eslint-plugin-svelte v2.28.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/require-each-key.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/require-each-key.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/require-each-key.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/require-each-key.ts)

--- a/docs/rules/require-event-dispatcher-types.md
+++ b/docs/rules/require-event-dispatcher-types.md
@@ -47,5 +47,5 @@ This rule was introduced in eslint-plugin-svelte v2.16.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/require-event-dispatcher-types.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/require-event-dispatcher-types.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/require-event-dispatcher-types.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/require-event-dispatcher-types.ts)

--- a/docs/rules/require-optimized-style-attribute.md
+++ b/docs/rules/require-optimized-style-attribute.md
@@ -104,5 +104,5 @@ This rule was introduced in eslint-plugin-svelte v0.32.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/require-optimized-style-attribute.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/require-optimized-style-attribute.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/require-optimized-style-attribute.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/require-optimized-style-attribute.ts)

--- a/docs/rules/require-store-callbacks-use-set-param.md
+++ b/docs/rules/require-store-callbacks-use-set-param.md
@@ -79,5 +79,5 @@ This rule was introduced in eslint-plugin-svelte v2.12.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/require-store-callbacks-use-set-param.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/require-store-callbacks-use-set-param.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/require-store-callbacks-use-set-param.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/require-store-callbacks-use-set-param.ts)

--- a/docs/rules/require-store-reactive-access.md
+++ b/docs/rules/require-store-reactive-access.md
@@ -97,5 +97,5 @@ This rule was introduced in eslint-plugin-svelte v2.12.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/require-store-reactive-access.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/require-store-reactive-access.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/require-store-reactive-access.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/require-store-reactive-access.ts)

--- a/docs/rules/require-stores-init.md
+++ b/docs/rules/require-stores-init.md
@@ -53,5 +53,5 @@ This rule was introduced in eslint-plugin-svelte v2.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/require-stores-init.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/require-stores-init.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/require-stores-init.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/require-stores-init.ts)

--- a/docs/rules/shorthand-attribute.md
+++ b/docs/rules/shorthand-attribute.md
@@ -67,5 +67,5 @@ This rule was introduced in eslint-plugin-svelte v0.5.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/shorthand-attribute.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/shorthand-attribute.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/shorthand-attribute.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/shorthand-attribute.ts)

--- a/docs/rules/shorthand-directive.md
+++ b/docs/rules/shorthand-directive.md
@@ -74,5 +74,5 @@ This rule was introduced in eslint-plugin-svelte v0.24.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/shorthand-directive.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/shorthand-directive.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/shorthand-directive.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/shorthand-directive.ts)

--- a/docs/rules/sort-attributes.md
+++ b/docs/rules/sort-attributes.md
@@ -275,5 +275,5 @@ This rule was introduced in eslint-plugin-svelte v2.4.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/sort-attributes.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/sort-attributes.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/sort-attributes.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/sort-attributes.ts)

--- a/docs/rules/spaced-html-comment.md
+++ b/docs/rules/spaced-html-comment.md
@@ -56,5 +56,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.1
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/spaced-html-comment.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/spaced-html-comment.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/spaced-html-comment.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/spaced-html-comment.ts)

--- a/docs/rules/system.md
+++ b/docs/rules/system.md
@@ -26,5 +26,5 @@ This rule was introduced in eslint-plugin-svelte v0.0.13
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/system.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/system.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/system.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/system.ts)

--- a/docs/rules/valid-compile.md
+++ b/docs/rules/valid-compile.md
@@ -113,5 +113,5 @@ This rule was introduced in eslint-plugin-svelte v0.7.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/valid-compile.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/valid-compile.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/valid-compile.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/valid-compile.ts)

--- a/docs/rules/valid-each-key.md
+++ b/docs/rules/valid-each-key.md
@@ -63,5 +63,5 @@ This rule was introduced in eslint-plugin-svelte v2.28.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/valid-each-key.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/valid-each-key.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/valid-each-key.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/valid-each-key.ts)

--- a/docs/rules/valid-prop-names-in-kit-pages.md
+++ b/docs/rules/valid-prop-names-in-kit-pages.md
@@ -66,5 +66,5 @@ This rule was introduced in eslint-plugin-svelte v2.12.0
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/valid-prop-names-in-kit-pages.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/valid-prop-names-in-kit-pages.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/valid-prop-names-in-kit-pages.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/valid-prop-names-in-kit-pages.ts)

--- a/packages/eslint-plugin-svelte/tools/update-docs.ts
+++ b/packages/eslint-plugin-svelte/tools/update-docs.ts
@@ -144,8 +144,8 @@ This rule was introduced in eslint-plugin-svelte ${await this.since}
 				: ''
 		}## :mag: Implementation
 
-- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/src/rules/${ruleName}.ts)
-- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/tests/src/rules/${ruleName}.ts)
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/${ruleName}.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/${ruleName}.ts)
 ${
 	extensionRule
 		? typeof extensionRule === 'string'


### PR DESCRIPTION
The links from the docs were updated after migration to a monorepo

resolve: https://github.com/sveltejs/eslint-plugin-svelte/issues/810