### PR TITLE
[doc] Update README and user guide to use eslint flat format for TS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,56 +164,57 @@ module.exports = {
 };
 ```
 
-For example, if you are using the `"@typescript-eslint/parser"`, and if you want to use TypeScript in `<script>` of `.svelte`, you need to add more `parserOptions` configuration.
+For example, if you are using the `"typescript-eslint/parser"`, and if you want to use TypeScript in `<script>` of `.svelte`, you need to add more `parserOptions` configuration.
 
 ```js
-module.exports = {
-  // ...
-  extends: ['plugin:svelte/recommended'],
-  // ...
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    // ...
-    project: 'path/to/your/tsconfig.json',
-    extraFileExtensions: ['.svelte'] // This is a required setting in `@typescript-eslint/parser` v4.24.0.
-  },
-  overrides: [
-    {
-      files: ['*.svelte'],
-      parser: 'svelte-eslint-parser',
-      // Parse the `<script>` in `.svelte` as TypeScript by adding the following configuration.
+import svelteParser from 'svelte-eslint-parser';
+import tseslint from 'typescript-eslint';
+
+export default [
+  //...
+  {
+    files: ['**/*.ts', '**/*.js', '**/*.svelte', '**/*.cjs'],
+    languageOptions: {
+      parser: tseslint.parser,
       parserOptions: {
-        parser: '@typescript-eslint/parser'
+        //...
+        project: 'path/to/your/tsconfig.json',
+        extraFileExtensions: ['.svelte']
       }
     }
-    // ...
-  ]
-  // ...
-};
+  },
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parser: svelteParser,
+      parserOptions: {
+        parser: tseslint.parser
+      }
+    }
+  }
+];
 ```
 
 If you have a mix of TypeScript and JavaScript in your project, use a multiple parser configuration.
 
 ```js
-module.exports = {
+export default [
   // ...
-  overrides: [
-    {
-      files: ['*.svelte'],
-      parser: 'svelte-eslint-parser',
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parser: svelteParser,
       parserOptions: {
         parser: {
           // Specify a parser for each lang.
-          ts: '@typescript-eslint/parser',
+          ts: tseslint.parser,
           js: 'espree',
-          typescript: '@typescript-eslint/parser'
+          typescript: tseslint.parser
         }
       }
     }
-    // ...
-  ]
-  // ...
-};
+  }
+];
 ```
 
 See also <https://github.com/sveltejs/svelte-eslint-parser#readme>.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -115,56 +115,57 @@ module.exports = {
 };
 ```
 
-For example, if you are using the `"@typescript-eslint/parser"`, and if you want to use TypeScript in `<script>` of `.svelte`, you need to add more `parserOptions` configuration.
+For example, if you are using the `"typescript-eslint/parser"`, and if you want to use TypeScript in `<script>` of `.svelte`, you need to add more `parserOptions` configuration.
 
 ```js
-module.exports = {
-  // ...
-  extends: ['plugin:svelte/recommended'],
-  // ...
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    // ...
-    project: 'path/to/your/tsconfig.json',
-    extraFileExtensions: ['.svelte'] // This is a required setting in `@typescript-eslint/parser` v4.24.0.
-  },
-  overrides: [
-    {
-      files: ['*.svelte'],
-      parser: 'svelte-eslint-parser',
-      // Parse the `<script>` in `.svelte` as TypeScript by adding the following configuration.
+import svelteParser from 'svelte-eslint-parser';
+import tseslint from 'typescript-eslint';
+
+export default [
+  //...
+  {
+    files: ['**/*.ts', '**/*.js', '**/*.svelte', '**/*.cjs'],
+    languageOptions: {
+      parser: tseslint.parser,
       parserOptions: {
-        parser: '@typescript-eslint/parser'
+        //...
+        project: 'path/to/your/tsconfig.json',
+        extraFileExtensions: ['.svelte']
       }
     }
-    // ...
-  ]
-  // ...
-};
+  },
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parser: svelteParser,
+      parserOptions: {
+        parser: tseslint.parser
+      }
+    }
+  }
+];
 ```
 
 If you have a mix of TypeScript and JavaScript in your project, use a multiple parser configuration.
 
 ```js
-module.exports = {
+export default [
   // ...
-  overrides: [
-    {
-      files: ['*.svelte'],
-      parser: 'svelte-eslint-parser',
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parser: svelteParser,
       parserOptions: {
         parser: {
           // Specify a parser for each lang.
-          ts: '@typescript-eslint/parser',
+          ts: tseslint.parser,
           js: 'espree',
-          typescript: '@typescript-eslint/parser'
+          typescript: tseslint.parser
         }
       }
     }
-    // ...
-  ]
-  // ...
-};
+  }
+];
 ```
 
 See also <https://github.com/sveltejs/svelte-eslint-parser#readme>.


### PR DESCRIPTION
This PR updates the TS sections in README and `user-guide.md` by replacing the legacy `eslintrc.*` configuration with the eslint flat config `eslint.config.js`.