### PR TITLE
chore: Avoid using deprecated FlatConfig eslint type

### DIFF
--- a/.changeset/warm-eyes-boil.md
+++ b/.changeset/warm-eyes-boil.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+chore: Avoid using deprecated FlatConfig eslint type

--- a/docs-svelte-kit/eslint.config.mjs
+++ b/docs-svelte-kit/eslint.config.mjs
@@ -2,7 +2,7 @@ import * as myPlugin from '@ota-meshi/eslint-plugin';
 import globals from 'globals';
 
 /**
- * @type {import('eslint').Linter.FlatConfig[]}
+ * @type {import('eslint').Linter.Config[]}
  */
 const config = [
 	{

--- a/docs-svelte-kit/src/lib/eslint/scripts/linter.js
+++ b/docs-svelte-kit/src/lib/eslint/scripts/linter.js
@@ -125,7 +125,7 @@ export function getRule(ruleId) {
 }
 
 /**
- * @returns {import('eslint').Linter.FlatConfig[]}
+ * @returns {import('eslint').Linter.Config[]}
  */
 export function createLinterConfig() {
 	return [

--- a/packages/eslint-plugin-svelte/eslint.config.mjs
+++ b/packages/eslint-plugin-svelte/eslint.config.mjs
@@ -2,7 +2,7 @@ import * as myPlugin from '@ota-meshi/eslint-plugin';
 import * as tseslint from 'typescript-eslint';
 
 /**
- * @type {import('eslint').Linter.FlatConfig[]}
+ * @type {import('eslint').Linter.Config[]}
  */
 const config = [
 	{

--- a/packages/eslint-plugin-svelte/src/configs/flat/all.ts
+++ b/packages/eslint-plugin-svelte/src/configs/flat/all.ts
@@ -1,7 +1,7 @@
 import type { Linter } from 'eslint';
 import { rules } from '../../utils/rules';
 import base from './base';
-const config: Linter.FlatConfig[] = [
+const config: Linter.Config[] = [
 	...base,
 	{
 		name: 'svelte:all:rules',


### PR DESCRIPTION
This type has been deprecated in eslint, see https://github.com/eslint/eslint/blob/71f37c5bf04afb704232d312cc6c72c957d1c14e/lib/types/index.d.ts#L1306