### PR TITLE
fix: correct new rule docs path

### DIFF
--- a/packages/eslint-plugin-svelte/tools/new-rule.ts
+++ b/packages/eslint-plugin-svelte/tools/new-rule.ts
@@ -21,7 +21,7 @@ void (async (ruleId) => {
 
 	const ruleFile = path.resolve(__dirname, `../src/rules/${ruleId}.ts`);
 	const testFile = path.resolve(__dirname, `../tests/src/rules/${ruleId}.ts`);
-	const docFile = path.resolve(__dirname, `../docs/rules/${ruleId}.md`);
+	const docFile = path.resolve(__dirname, `../../../docs/rules/${ruleId}.md`);
 	const fixturesRoot = path.resolve(__dirname, `../tests/fixtures/rules/${ruleId}/`);
 	try {
 		fs.mkdirSync(path.dirname(ruleFile), { recursive: true });


### PR DESCRIPTION
Current `new-rule.ts` script generates a doc inside the
`./packages/eslint-plugin-svelte`, instead of creating a doc in the actual
`./docs` folder.
