### PR TITLE
fix: correct `svelte/html-closing-bracket-new-line` docs

### DIFF
--- a/docs/rules/html-closing-bracket-new-line.md
+++ b/docs/rules/html-closing-bracket-new-line.md
@@ -23,7 +23,7 @@ This rule enforces a line break (or no line break) before tag's closing brackets
 
 ```svelte
 <script>
-  /* eslint svelte/brackets-same-line: "error" */
+  /* eslint svelte/html-closing-bracket-new-line: "error" */
 </script>
 
 <!-- ✓ GOOD -->
@@ -60,9 +60,9 @@ This rule enforces a line break (or no line break) before tag's closing brackets
 
 ## :wrench: Options
 
-```jsonc
+```json
 {
-  "svelte/brackets-same-line": [
+  "svelte/html-closing-bracket-new-line": [
     "error",
     {
       "singleline": "never", // ["never", "always"]


### PR DESCRIPTION
Correcting:

- [Comment 1](https://github.com/sveltejs/eslint-plugin-svelte/pull/870#discussion_r1841785961)
- [Comment 2](https://github.com/sveltejs/eslint-plugin-svelte/pull/870#discussion_r1841786863)

Thanks to @noy4 for pointing the issues out.
