### PR TITLE
chore: downgraded eslint to 9.14 to prevent incompatibility with typescript-eslint

### DIFF
--- a/.changeset/violet-cobras-tap.md
+++ b/.changeset/violet-cobras-tap.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+chore: temporarily downgraded eslint to fix an incompatibility with typescript-eslint

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "env-cmd": "^10.1.0",
-    "eslint": "^9.12.0",
+    "eslint": "^9.14.0 <9.15",
     "eslint-config-prettier": "^9.1.0",
     "eslint-formatter-friendly": "^7.0.0",
     "eslint-plugin-eslint-plugin": "^6.2.0",


### PR DESCRIPTION
Temporarily fixes #923
