### PR TITLE
fix: prevent infinite recurstion in indent

### DIFF
--- a/packages/eslint-plugin-svelte/src/rules/indent-helpers/offset-context.ts
+++ b/packages/eslint-plugin-svelte/src/rules/indent-helpers/offset-context.ts
@@ -48,6 +48,10 @@ export class OffsetContext {
 		if (index === base) {
 			return;
 		}
+		const previousOffset = this.offsets.get(index);
+		if (previousOffset?.type === 2) {
+			return;
+		}
 		this.offsets.set(index, {
 			type: OffsetDataType.normal,
 			base,

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo-errors.yaml
@@ -1,0 +1,8 @@
+- message: Expected indentation of 2 spaces but found 0 spaces.
+  line: 2
+  column: 1
+  suggestions: null
+- message: Expected indentation of 2 spaces but found 0 spaces.
+  line: 3
+  column: 1
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo-input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+enum A { a }
+$a
+</script>
+
+<!--tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo.svelte-->

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo-output.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  enum A { a }
+  $a
+</script>
+
+<!--tests/fixtures/rules/indent/invalid/ts/ts-enum-destore-combo.svelte-->


### PR DESCRIPTION
The error here is tricky to track down the root cause of (especially for someone new to the codebase) but the trigger for it as I understand is as follows:

1. The indent rule begins to build `offsets` as a map of token beginnings to indent levels, each referencing its own parent. Among them are "root nodes" ­— entries in the map which have a `type` of 2 and no parent.
2. A token will arrive with a starting index which overlaps a root node.
3. The offset builder then inserts this new offset on top of the root node, providing it a new parent.
4. This parent originally depended on that root node at some point in its ancestor chain, and thus a circular dependency is created.
5. When later resolving this circular dependency, infinite recursion is occurs. This results in a stack limit error, crashing the program.

The ideal solution is probably to avoid inserting these tokens which overlap root nodes, or possibly disambiguate offsets by more than simply the start index. The fix here (simply ignoring attempts to overwrite root nodes) passes all the existing tests as far as I can see but I have not had time to extensively test it and simply discarding the information seems misguided — though I cannot currently imagine a scenario where the token which overlaps the root has a different indent level from the node that it overlaps.

The test here is far from ideal but serves to demonstrate a reproducible case of the bug. Having something to check for this sort of error is good, but someone with more knowledge of the root cause might be able to produce a better fix and related test. Of note, it seems to be the most minimal viable example I can find since the following changes prevented the error from occurring:

- Removing the store unwrap token (`$`)
- Removing the Enum
- Making the Enum empty
- Changing the script lang attribute to the empty string
- Removing the script lang attribute
- Adding `<!-- prettier-ignore -->` to the top of the file