### PR TITLE
fix: ignore `css_unused_selector` error if style is global

### DIFF
--- a/.changeset/nice-clocks-buy.md
+++ b/.changeset/nice-clocks-buy.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: ignore css_unused_selector error if style tag has global attribute

--- a/packages/eslint-plugin-svelte/src/rules/valid-compile.ts
+++ b/packages/eslint-plugin-svelte/src/rules/valid-compile.ts
@@ -2,6 +2,7 @@ import { createRule } from '../utils/index.js';
 import type { SvelteCompileWarnings, Warning } from '../shared/svelte-compile-warns/index.js';
 import { getSvelteCompileWarnings } from '../shared/svelte-compile-warns/index.js';
 import { getSourceCode } from '../utils/compat.js';
+import type { Position } from 'svelte-eslint-parser/lib/ast/common.js';
 
 export default createRule('valid-compile', {
 	meta: {
@@ -48,12 +49,33 @@ export default createRule('valid-compile', {
 			'invalid-slot-name'
 		];
 
+		const unusedSelectorWarnings = ['css_unused_selector', 'css-unused-selector'];
+		const globalStyleRanges: [Position, Position][] = [];
+
+		function isGlobalStyleNode(start?: Position, end?: Position) {
+			if (start == null || end == null) {
+				return false;
+			}
+			return globalStyleRanges.some(([rangeStart, rangeEnd]) => {
+				return (
+					(rangeStart.line < start.line ||
+						(rangeStart.line === start.line && rangeStart.column <= start.column)) &&
+					(end.line < rangeEnd.line ||
+						(end.line === rangeEnd.line && end.column <= rangeEnd.column))
+				);
+			});
+		}
+
 		/**
 		 * report
 		 */
 		function report({ warnings, kind }: SvelteCompileWarnings) {
 			for (const warn of warnings) {
-				if (warn.code && ignores.includes(warn.code)) {
+				if (
+					warn.code &&
+					(ignores.includes(warn.code) ||
+						(isGlobalStyleNode(warn.start, warn.end) && unusedSelectorWarnings.includes(warn.code)))
+				) {
 					continue;
 				}
 				const reportWarn = kind === 'warn' ? transform(warn) : warn;
@@ -71,6 +93,15 @@ export default createRule('valid-compile', {
 		}
 
 		return {
+			SvelteStyleElement(node) {
+				const { attributes } = node.startTag;
+				for (const attr of attributes) {
+					if (attr.type === 'SvelteAttribute' && attr.key.name === 'global') {
+						globalStyleRanges.push([node.loc.start, node.loc.end]);
+						break;
+					}
+				}
+			},
 			'Program:exit'() {
 				const result = getSvelteCompileWarnings(context);
 				if (ignoreWarnings && result.kind === 'warn') {

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-compile/valid/global-style-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-compile/valid/global-style-input.svelte
@@ -1,0 +1,5 @@
+<style global>
+	input {
+		@apply bg-surface-50-900-token h-full overflow-hidden;
+	}
+</style>


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/577