### PR TITLE
chore: remove `typescript-eslint` v5 test

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -139,31 +139,6 @@ jobs:
         run: pnpm run test
         working-directory: ${{ env.project_root_path }}
 
-  test-for-typescript-eslint-v5:
-    name: Test for typescript-eslint v5
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node: [18]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-      - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-      - name: Install typescript-eslint v5
-        run: |
-          pnpm install -D -w @typescript-eslint/parser@5 @typescript-eslint/eslint-plugin@5
-          rm -rf node_modules
-      - name: Install Packages
-        run: pnpm install
-      - name: Test
-        run: pnpm run test
-        working-directory: ${{ env.project_root_path }}
-
   update-resources:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We support ESLint >= `8.57.0`, therefore, we don't need to test with `typescript-eslint` < 8.
Because `typescript-eslint` v7 supports ESLint >= 8.56.0. (`eslint-plugin-svelte` doesn't support ESLint `8.56.0`)
https://github.com/typescript-eslint/typescript-eslint/blob/v7.18.0/packages/eslint-plugin/package.json#L101