### PR TITLE
chore: make properties in `parserServices` optional

### DIFF
--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -111,7 +111,7 @@ function findClassesInPostCSSNode(
 ): string[] {
 	if (node.type === 'rule') {
 		let classes = node.nodes.flatMap((node) => findClassesInPostCSSNode(node, parserServices));
-		classes = classes.concat(findClassesInSelector(parserServices.getStyleSelectorAST(node)));
+		classes = classes.concat(findClassesInSelector(parserServices.getStyleSelectorAST!(node)));
 		return classes;
 	}
 	if ((node.type === 'root' || node.type === 'atrule') && node.nodes !== undefined) {

--- a/packages/eslint-plugin-svelte/src/types.ts
+++ b/packages/eslint-plugin-svelte/src/types.ts
@@ -210,10 +210,10 @@ export interface SourceCode {
 		isSvelteScript?: boolean;
 		getSvelteHtmlAst?: () => unknown;
 		getStyleContext?: () => StyleContext;
-		getStyleSelectorAST: (rule: StyleRule) => SelectorRoot;
-		styleNodeLoc: (node: Node) => Partial<SourceLocation>;
-		styleNodeRange: (node: Node) => [number | undefined, number | undefined];
-		styleSelectorNodeLoc: (node: SelectorNode) => Partial<SourceLocation>;
+		getStyleSelectorAST?: (rule: StyleRule) => SelectorRoot;
+		styleNodeLoc?: (node: Node) => Partial<SourceLocation>;
+		styleNodeRange?: (node: Node) => [number | undefined, number | undefined];
+		styleSelectorNodeLoc?: (node: SelectorNode) => Partial<SourceLocation>;
 		svelteParseContext?: {
 			/**
 			 * Whether to use Runes mode.


### PR DESCRIPTION
I think all properties should be optional because the functions that exist depend on which parser is used.