### PR TITLE
fix: update method for extracting major version

### DIFF
--- a/.changeset/two-students-pump.md
+++ b/.changeset/two-students-pump.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: update method for extracting major version

--- a/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
+++ b/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
@@ -145,7 +145,7 @@ function getSvelteVersion(filePath: string): SvelteContext['svelteVersion'] {
 			if (typeof version !== 'string') {
 				continue;
 			}
-			const major = version.split('.')[0];
+			const major = extractMajorVersion(version);
 			if (major === '3' || major === '4') {
 				return '3/4';
 			}
@@ -185,12 +185,24 @@ function getSvelteKitVersion(filePath: string): SvelteContext['svelteKitVersion'
 			if (typeof version !== 'string') {
 				return null;
 			}
-			return version.split('.')[0] as SvelteContext['svelteKitVersion'];
+
+			if (version.includes('1.0.0-next')) {
+				return '1.0.0-next';
+			}
+			return extractMajorVersion(version) as SvelteContext['svelteKitVersion'];
 		}
 	} catch {
 		/** do nothing */
 	}
 
+	return null;
+}
+
+function extractMajorVersion(version: string): string | null {
+	const match = /^(?:\^|~)?(\d+)\./.exec(version);
+	if (match && match[1]) {
+		return match[1];
+	}
 	return null;
 }
 

--- a/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
+++ b/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
@@ -145,7 +145,7 @@ function getSvelteVersion(filePath: string): SvelteContext['svelteVersion'] {
 			if (typeof version !== 'string') {
 				continue;
 			}
-			const major = extractMajorVersion(version);
+			const major = extractMajorVersion(version, false);
 			if (major === '3' || major === '4') {
 				return '3/4';
 			}
@@ -186,10 +186,7 @@ function getSvelteKitVersion(filePath: string): SvelteContext['svelteKitVersion'
 				return null;
 			}
 
-			if (version.includes('1.0.0-next')) {
-				return '1.0.0-next';
-			}
-			return extractMajorVersion(version) as SvelteContext['svelteKitVersion'];
+			return extractMajorVersion(version, true) as SvelteContext['svelteKitVersion'];
 		}
 	} catch {
 		/** do nothing */
@@ -198,7 +195,14 @@ function getSvelteKitVersion(filePath: string): SvelteContext['svelteKitVersion'
 	return null;
 }
 
-function extractMajorVersion(version: string): string | null {
+function extractMajorVersion(version: string, recognizePrereleaseVersion: boolean): string | null {
+	if (recognizePrereleaseVersion) {
+		const match = /^(?:\^|~)?(\d+\.0\.0-next)/.exec(version);
+		if (match && match[1]) {
+			return match[1];
+		}
+	}
+
 	const match = /^(?:\^|~)?(\d+)\./.exec(version);
 	if (match && match[1]) {
 		return match[1];


### PR DESCRIPTION
This PR addresses a bug in the method for extracting the library’s major version. While it does not support all possible version specification methods, I believe it is sufficient for extracting the major version of Svelte and SvelteKit.
This bug is introduced in https://github.com/sveltejs/eslint-plugin-svelte/pull/980.