### PR TITLE
chore: do not run `no-reactive-reassign` rule on Svelte 5 with runes

### DIFF
--- a/.changeset/perfect-mirrors-doubt.md
+++ b/.changeset/perfect-mirrors-doubt.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+chore: do not run `no-reactive-reassign` rule on Svelte 5 with runes

--- a/packages/eslint-plugin-svelte/src/rules/no-reactive-reassign.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-reactive-reassign.ts
@@ -27,7 +27,16 @@ export default createRule('no-reactive-reassign', {
 			assignmentToReactiveValue: "Assignment to reactive value '{{name}}'.",
 			assignmentToReactiveValueProp: "Assignment to property of reactive value '{{name}}'."
 		},
-		type: 'problem'
+		type: 'problem',
+		conditions: [
+			{
+				svelteVersions: ['3/4']
+			},
+			{
+				svelteVersions: ['5'],
+				runes: [false, 'undetermined']
+			}
+		]
 	},
 	create(context) {
 		const props = context.options[0]?.props !== false; // default true


### PR DESCRIPTION
The Svelte 5 compiler throws an error if a `$derived` value is reassigned. For object values, it’s better to use `const` instead of `let`. This will be addressed by https://github.com/sveltejs/eslint-plugin-svelte/pull/985

```svelte
<script>
  let count = $state(1);
	let double = $derived(count * 2);

	let obj = $state({ foo: 1 });
	let derivedObj = $derived( { ...obj, bar: true });

	function invalid() {
		double = double + 1;
		derivedObj.bar = false;
	}
</script>

```

https://svelte.dev/playground/hello-world?version=5.17.3#H4sIAAAAAAAAE22PwU7EMAxEf8WyOLRQBZVjdheJGzc-gHBIGlfKKptUiVtAVf8dZdstHLhZM2_G9oxBXwglvpL3ET5j8hYqso7J1thg7zxllO8z8vdQuCJgc0u9DIPIE3kumtGZ_tO7GJgCZ5R4zF1yAz-rAOCJoYtjYDjBXWbNVLX1QQXFxbFxNJ6KZSm5iWy1svfwdIU2LJrzb3yGPkYJLSx_etb028rdumAGIUQ05waMThI4jbSlguJ-DB27GMCFSXtnqxrmoiver9qGB2gPm7PvEUYnOEGvfaaruahwfNwfxwaZvhhl2bl8LD9gOIRsggEAAA==