### PR TITLE
feat: set `languageOptions.globals` in base config

### DIFF
--- a/packages/eslint-plugin-svelte/package.json
+++ b/packages/eslint-plugin-svelte/package.json
@@ -60,6 +60,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "eslint-compat-utils": "^0.6.4",
     "esutils": "^2.0.3",
+    "globals": "^15.14.0",
     "known-css-properties": "^0.35.0",
     "postcss": "^8.4.49",
     "postcss-load-config": "^3.1.4",

--- a/packages/eslint-plugin-svelte/src/configs/flat/base.ts
+++ b/packages/eslint-plugin-svelte/src/configs/flat/base.ts
@@ -2,6 +2,7 @@
 // This file has been automatically generated,
 // in order to update its content execute "pnpm run update"
 import type { ESLint, Linter } from 'eslint';
+import globals from 'globals';
 import * as parser from 'svelte-eslint-parser';
 let pluginObject: ESLint.Plugin | null = null;
 export function setPluginObject(plugin: ESLint.Plugin): void {
@@ -14,13 +15,21 @@ const config: Linter.Config[] = [
 			get svelte(): ESLint.Plugin {
 				return pluginObject!;
 			}
+		},
+		languageOptions: {
+			globals: {
+				...globals.browser
+			}
 		}
 	},
 	{
 		name: 'svelte:base:setup-for-svelte',
 		files: ['*.svelte', '**/*.svelte'],
 		languageOptions: {
-			parser
+			parser,
+			globals: {
+				...globals.browser
+			}
 		},
 		rules: {
 			// ESLint core rules known to cause problems with `.svelte`.

--- a/packages/eslint-plugin-svelte/tools/update-rulesets.ts
+++ b/packages/eslint-plugin-svelte/tools/update-rulesets.ts
@@ -14,6 +14,7 @@ const baseContent = `/*
  * in order to update its content execute "pnpm run update"
  */
 import type { ESLint, Linter } from 'eslint';
+import globals from 'globals';
 import * as parser from 'svelte-eslint-parser';
 let pluginObject: ESLint.Plugin | null = null;
 export function setPluginObject(plugin: ESLint.Plugin): void {
@@ -27,12 +28,20 @@ const config: Linter.Config[] = [
         return pluginObject!;
       }
     },
+    languageOptions: {
+      globals: {
+        ...globals.browser
+      },
+    },
   },
   {
     name: 'svelte:base:setup-for-svelte',
     files: ["*.svelte", "**/*.svelte"],
     languageOptions: {
       parser: parser,
+      globals: {
+        ...globals.browser
+      },
     },
     rules: {
       // ESLint core rules known to cause problems with \`.svelte\`.


### PR DESCRIPTION

`eslint-plugin-svelte`'s config does not have `languageOptions.globals`.
https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/configs/flat/base.ts

I think many Svelte applications require `globals.browser`, so is it worth providing it in the base config?

references:
- `docs-svelte-kit` set `globals.browser`: https://github.com/sveltejs/eslint-plugin-svelte/blob/main/docs-svelte-kit/eslint.config.mjs#L34
- `eslint-plugin-vue` provides `globals.browser` in base config: https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/configs/flat/base.js#L17