### PR TITLE
fix: account for \n and \r in `TemplateLiteral` handling for the `no-useless-mustaches` rule

### DIFF
--- a/.changeset/old-numbers-pull.md
+++ b/.changeset/old-numbers-pull.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: account for \n and \r in `TemplateLiteral` handling for the `no-useless-mustaches` rule

--- a/packages/eslint-plugin-svelte/src/rules/no-useless-mustaches.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-useless-mustaches.ts
@@ -81,6 +81,10 @@ export default createRule('no-useless-mustaches', {
 				return;
 			}
 
+			if (expression.type === 'TemplateLiteral' && /[\n\r]/.test(rawValue)) {
+				return;
+			}
+
 			let hasEscape = false;
 			if (rawValue !== strValue) {
 				// check escapes

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-useless-mustaches/valid/valid-test02-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-useless-mustaches/valid/valid-test02-input.svelte
@@ -1,0 +1,5 @@
+<HyperMD
+	value={`# Doc
+
+Text goes here`}
+/>


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1036