### PR TITLE
chore: update pkg.pr.new workflow

### DIFF
--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -1,0 +1,31 @@
+name: Update pkg.pr.new comment
+
+on:
+  workflow_run:
+    workflows: ['Publish to pkg.pr.new']
+    types:
+      - completed
+
+jobs:
+  build:
+    if: github.repository == 'sveltejs/eslint-plugin-svelte'
+    name: 'Update comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: output
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - run: ls -R .
+      - name: 'Post or update comment'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+            const { default: process } = await import('${{ github.workspace }}/tools/pkg.pr.new-comment.mjs')
+
+            await process({github, context, core, output})

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,14 +1,10 @@
-name: Publish to pkg.pr.new
+name: Publish Any Commit
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
     tags: ['!**']
-
-permissions:
-  issues: write
-  pull-requests: write
 
 jobs:
   build:
@@ -24,12 +20,21 @@ jobs:
       - name: Build
         run: pnpm run build
       - run: pnpx pkg-pr-new publish --compact './packages/eslint-plugin-svelte' --json output.json --comment=off
-      - uses: actions/github-script@v7
+      - name: Add metadata to output
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
-            const { default: process } = await import('${{ github.workspace }}/tools/pkg.pr.new-comment.mjs')
+            output.number = context.issue.number;
+            output.event_name = context.eventName;
+            output.ref = context.ref;
+            fs.writeFileSync('output.json', JSON.stringify(output), 'utf8');
+      - name: Upload output
+        uses: actions/upload-artifact@v4
+        with:
+          name: output
+          path: ./output.json
 
-            await process({github, context, core, output})
+      - run: ls -R .

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,4 +1,4 @@
-name: Publish Any Commit
+name: Publish to pkg.pr.new
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
This PR changes the workflow of pkg.pr.new.

The workflow of #1054 is failing with 403 error.
I expect that by splitting the workflow in this PR based on the svelte repository, we can avoid the 403 error.