### PR TITLE
feat: add `excludedRunes` option to the `prefer-const` rule

### DIFF
--- a/.changeset/sixty-cars-fail.md
+++ b/.changeset/sixty-cars-fail.md
@@ -1,5 +1,5 @@
 ---
-'eslint-plugin-svelte': patch
+'eslint-plugin-svelte': minor
 ---
 
-fix: ignore `$state` in the `prefer-const` rule
+feat: add `excludedRunes` option to the `prefer-const` rule

--- a/.changeset/sixty-cars-fail.md
+++ b/.changeset/sixty-cars-fail.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: ignore `$state` in the `prefer-const` rule

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -14,7 +14,7 @@ since: 'v3.0.0-next.6'
 
 ## :book: Rule Details
 
-This rule reports the same as the base ESLint `prefer-const` rule, except that ignores Svelte reactive values such as `$derived`, `$state`, and `$props`. If this rule is active, make sure to disable the base `prefer-const` rule, as it will conflict with this rule.
+This rule reports the same as the base ESLint `prefer-const` rule, except that ignores Svelte reactive values such as `$derived` and `$props` as default. If this rule is active, make sure to disable the base `prefer-const` rule, as it will conflict with this rule.
 
 <!--eslint-skip-->
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -14,7 +14,7 @@ since: 'v3.0.0-next.6'
 
 ## :book: Rule Details
 
-This rule reports the same as the base ESLint `prefer-const` rule, except that ignores Svelte reactive values such as `$derived` and `$props`. If this rule is active, make sure to disable the base `prefer-const` rule, as it will conflict with this rule.
+This rule reports the same as the base ESLint `prefer-const` rule, except that ignores Svelte reactive values such as `$derived`, `$state`, and `$props`. If this rule is active, make sure to disable the base `prefer-const` rule, as it will conflict with this rule.
 
 <!--eslint-skip-->
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -46,7 +46,8 @@ This rule reports the same as the base ESLint `prefer-const` rule, except that i
     "error",
     {
       "destructuring": "any",
-      "ignoreReadonly": true
+      "ignoreReadonly": true,
+      "excludedRunes": ["$props", "$state"]
     }
   ]
 }
@@ -56,6 +57,7 @@ This rule reports the same as the base ESLint `prefer-const` rule, except that i
   - `any` (default): if any variables in destructuring should be const, this rule warns for those variables.
   - `all`: if all variables in destructuring should be const, this rule warns the variables. Otherwise, ignores them.
 - `ignoreReadonly`: If `true`, this rule will ignore variables that are read between the declaration and the _first_ assignment.
+- `excludedRunes`: An array of rune names that should be ignored. Even if a rune is declared with `let`, it will still be ignored.
 
 ## :books: Further Reading
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -47,7 +47,7 @@ This rule reports the same as the base ESLint `prefer-const` rule, except that i
     {
       "destructuring": "any",
       "ignoreReadonly": true,
-      "excludedRunes": ["$props", "$state"]
+      "excludedRunes": ["$props", "$derived"]
     }
   ]
 }

--- a/packages/eslint-plugin-svelte/src/rule-types.ts
+++ b/packages/eslint-plugin-svelte/src/rule-types.ts
@@ -523,6 +523,9 @@ type SveltePreferClassDirective = []|[{
 }]
 // ----- svelte/prefer-const -----
 type SveltePreferConst = []|[{
+  destructuring?: ("any" | "all")
+  ignoreReadBeforeAssign?: boolean
+  additionalProperties?: never
   excludedRunes?: string[]
   [k: string]: unknown | undefined
 }]

--- a/packages/eslint-plugin-svelte/src/rule-types.ts
+++ b/packages/eslint-plugin-svelte/src/rule-types.ts
@@ -525,9 +525,7 @@ type SveltePreferClassDirective = []|[{
 type SveltePreferConst = []|[{
   destructuring?: ("any" | "all")
   ignoreReadBeforeAssign?: boolean
-  additionalProperties?: never
   excludedRunes?: string[]
-  [k: string]: unknown | undefined
 }]
 // ----- svelte/shorthand-attribute -----
 type SvelteShorthandAttribute = []|[{

--- a/packages/eslint-plugin-svelte/src/rule-types.ts
+++ b/packages/eslint-plugin-svelte/src/rule-types.ts
@@ -523,8 +523,8 @@ type SveltePreferClassDirective = []|[{
 }]
 // ----- svelte/prefer-const -----
 type SveltePreferConst = []|[{
-  destructuring?: ("any" | "all")
-  ignoreReadBeforeAssign?: boolean
+  excludedRunes?: string[]
+  [k: string]: unknown | undefined
 }]
 // ----- svelte/shorthand-attribute -----
 type SvelteShorthandAttribute = []|[{

--- a/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
@@ -61,14 +61,14 @@ export default createRule('prefer-const', {
 				properties: {
 					destructuring: { enum: ['any', 'all'] },
 					ignoreReadBeforeAssign: { type: 'boolean' },
-					additionalProperties: false,
 					excludedRunes: {
 						type: 'array',
 						items: {
 							type: 'string'
 						}
 					}
-				}
+				},
+				additionalProperties: false
 			}
 		]
 	},

--- a/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
@@ -59,6 +59,9 @@ export default createRule('prefer-const', {
 			{
 				type: 'object',
 				properties: {
+					destructuring: { enum: ['any', 'all'] },
+					ignoreReadBeforeAssign: { type: 'boolean' },
+					additionalProperties: false,
 					excludedRunes: {
 						type: 'array',
 						items: {

--- a/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
@@ -31,7 +31,7 @@ function shouldSkipDeclaration(declaration: TSESTree.Expression | null) {
 		return false;
 	}
 
-	if (callee.type === 'Identifier' && ['$props', '$derived'].includes(callee.name)) {
+	if (callee.type === 'Identifier' && ['$props', '$state', '$derived'].includes(callee.name)) {
 		return true;
 	}
 
@@ -39,11 +39,7 @@ function shouldSkipDeclaration(declaration: TSESTree.Expression | null) {
 		return false;
 	}
 
-	if (
-		callee.object.name === '$derived' &&
-		callee.property.type === 'Identifier' &&
-		callee.property.name === 'by'
-	) {
+	if (callee.object.name === '$state' || callee.object.name === '$derived') {
 		return true;
 	}
 

--- a/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-const.ts
@@ -21,7 +21,7 @@ function findDeclarationCallee(node: TSESTree.Expression) {
  * Determines if a declaration should be skipped in the const preference analysis.
  * Specifically checks for Svelte's state management utilities ($props, $derived).
  */
-function shouldSkipDeclaration(declaration: TSESTree.Expression | null) {
+function shouldSkipDeclaration(declaration: TSESTree.Expression | null, excludedRunes: string[]) {
 	if (!declaration) {
 		return false;
 	}
@@ -31,7 +31,7 @@ function shouldSkipDeclaration(declaration: TSESTree.Expression | null) {
 		return false;
 	}
 
-	if (callee.type === 'Identifier' && ['$props', '$state', '$derived'].includes(callee.name)) {
+	if (callee.type === 'Identifier' && excludedRunes.includes(callee.name)) {
 		return true;
 	}
 
@@ -39,7 +39,7 @@ function shouldSkipDeclaration(declaration: TSESTree.Expression | null) {
 		return false;
 	}
 
-	if (callee.object.name === '$state' || callee.object.name === '$derived') {
+	if (excludedRunes.includes(callee.object.name)) {
 		return true;
 	}
 
@@ -54,16 +54,32 @@ export default createRule('prefer-const', {
 			category: 'Best Practices',
 			recommended: false,
 			extensionRule: 'prefer-const'
-		}
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					excludedRunes: {
+						type: 'array',
+						items: {
+							type: 'string'
+						}
+					}
+				}
+			}
+		]
 	},
 	create(context) {
+		const config = context.options[0] ?? {};
+		const excludedRunes = config.excludedRunes ?? ['$props', '$derived'];
+
 		return defineWrapperListener(coreRule, context, {
 			createListenerProxy(coreListener) {
 				return {
 					...coreListener,
 					VariableDeclaration(node) {
 						for (const decl of node.declarations) {
-							if (shouldSkipDeclaration(decl.init)) {
+							if (shouldSkipDeclaration(decl.init, excludedRunes)) {
 								return;
 							}
 						}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/_config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/_config.json
@@ -1,0 +1,3 @@
+{
+	"options": [{ "excludedRunes": [] }]
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/test01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/test01-errors.yaml
@@ -1,0 +1,20 @@
+- message: "'prop1' is never reassigned. Use 'const' instead."
+  line: 2
+  column: 8
+  suggestions: null
+- message: "'prop2' is never reassigned. Use 'const' instead."
+  line: 2
+  column: 15
+  suggestions: null
+- message: "'zero' is never reassigned. Use 'const' instead."
+  line: 3
+  column: 6
+  suggestions: null
+- message: "'derived' is never reassigned. Use 'const' instead."
+  line: 4
+  column: 6
+  suggestions: null
+- message: "'derivedBy' is never reassigned. Use 'const' instead."
+  line: 5
+  column: 6
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/test01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/test01-input.svelte
@@ -1,6 +1,6 @@
 <script>
 	let { prop1, prop2 } = $props();
-	const zero = $state(0);
+	let zero = $state(0);
 	let derived = $derived(zero * 2);
 	let derivedBy = $derived.by(calc());
 </script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/test01-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option1/test01-output.svelte
@@ -1,0 +1,6 @@
+<script>
+	const { prop1, prop2 } = $props();
+	const zero = $state(0);
+	const derived = $derived(zero * 2);
+	const derivedBy = $derived.by(calc());
+</script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/_config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/_config.json
@@ -1,0 +1,3 @@
+{
+	"options": [{ "excludedRunes": ["$state"] }]
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/test01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/test01-errors.yaml
@@ -1,0 +1,16 @@
+- message: "'prop1' is never reassigned. Use 'const' instead."
+  line: 2
+  column: 8
+  suggestions: null
+- message: "'prop2' is never reassigned. Use 'const' instead."
+  line: 2
+  column: 15
+  suggestions: null
+- message: "'derived' is never reassigned. Use 'const' instead."
+  line: 4
+  column: 6
+  suggestions: null
+- message: "'derivedBy' is never reassigned. Use 'const' instead."
+  line: 5
+  column: 6
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/test01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/test01-input.svelte
@@ -1,6 +1,6 @@
 <script>
 	let { prop1, prop2 } = $props();
-	const zero = $state(0);
+	let zero = $state(0);
 	let derived = $derived(zero * 2);
 	let derivedBy = $derived.by(calc());
 </script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/test01-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/option2/test01-output.svelte
@@ -1,0 +1,6 @@
+<script>
+	const { prop1, prop2 } = $props();
+	let zero = $state(0);
+	const derived = $derived(zero * 2);
+	const derivedBy = $derived.by(calc());
+</script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-errors.yaml
@@ -2,14 +2,6 @@
   line: 3
   column: 6
   suggestions: null
-- message: "'state' is never reassigned. Use 'const' instead."
-  line: 4
-  column: 6
-  suggestions: null
-- message: "'raw' is never reassigned. Use 'const' instead."
-  line: 5
-  column: 6
-  suggestions: null
 - message: "'doubled' is never reassigned. Use 'const' instead."
   line: 6
   column: 6

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-errors.yaml
@@ -2,6 +2,14 @@
   line: 3
   column: 6
   suggestions: null
+- message: "'state' is never reassigned. Use 'const' instead."
+  line: 4
+  column: 6
+  suggestions: null
+- message: "'raw' is never reassigned. Use 'const' instead."
+  line: 5
+  column: 6
+  suggestions: null
 - message: "'doubled' is never reassigned. Use 'const' instead."
   line: 6
   column: 6

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-output.svelte
@@ -1,8 +1,8 @@
 <script>
 	let { prop1, prop2 } = $props();
 	const zero = 0;
-	let state = $state(0);
-	let raw = $state.raw(0);
+	const state = $state(0);
+	const raw = $state.raw(0);
 	const doubled = state * 2;
 	let derived = $derived(state * 2);
 	const calculated = calc();

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/invalid/test01-output.svelte
@@ -1,8 +1,8 @@
 <script>
 	let { prop1, prop2 } = $props();
 	const zero = 0;
-	const state = $state(0);
-	const raw = $state.raw(0);
+	let state = $state(0);
+	let raw = $state.raw(0);
 	const doubled = state * 2;
 	let derived = $derived(state * 2);
 	const calculated = calc();

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option1/_config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option1/_config.json
@@ -1,0 +1,3 @@
+{
+	"options": [{ "excludedRunes": [] }]
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option1/test01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option1/test01-input.svelte
@@ -1,0 +1,6 @@
+<script>
+	const { prop1, prop2 } = $props();
+	const zero = $state(0);
+	const derived = $derived(zero * 2);
+	const derivedBy = $derived.by(calc());
+</script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option2/_config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option2/_config.json
@@ -1,0 +1,3 @@
+{
+	"options": [{ "excludedRunes": ["$props", "$derived", "$state"] }]
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option2/test01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-const/valid/option2/test01-input.svelte
@@ -1,6 +1,6 @@
 <script>
 	let { prop1, prop2 } = $props();
-	const zero = $state(0);
+	let zero = $state(0);
 	let derived = $derived(zero * 2);
 	let derivedBy = $derived.by(calc());
 </script>


### PR DESCRIPTION
close part of https://github.com/sveltejs/eslint-plugin-svelte/issues/818

As explained here, `$state` also needs to be excluded from the `prefer-const` rule.
https://github.com/sveltejs/eslint-plugin-svelte/pull/985#issuecomment-2566907151