### PR TITLE
docs: clarify versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If you’re migrating from `eslint-plugin-svelte` v1 or [`@ota-meshi/eslint-plug
 
 ## Versioning Policy
 
-This project follows [Semantic Versioning](https://semver.org/). Unlike [ESLint’s versioning policy](https://github.com/eslint/eslint#semantic-versioning-policy), new rules may be added in minor releases. If these new rules cause unwanted warnings, you can disable them.
+This project follows [Semantic Versioning](https://semver.org/). Unlike [ESLint’s versioning policy](https://github.com/eslint/eslint#semantic-versioning-policy), new rules may be added to the recommended config in minor releases. If these rules cause unwanted warnings, you can disable them.
 
 <!--DOCS_IGNORE_END-->
 


### PR DESCRIPTION
As discussed in https://github.com/sveltejs/eslint-plugin-svelte/commit/083ea48dfac10c3c084f830c758c3d6249bc8a68#r153008818

> According to ESLint’s versioning rules, new rules are not added to the recommended config in minor releases. This means users will not encounter new lint errors when upgrading minor/patch versions.
>
> However, eslint-plugin-svelte v3 does not follow this rule.

The README link in the [v3.0.0 release](https://github.com/sveltejs/eslint-plugin-svelte/releases/tag/eslint-plugin-svelte%403.0.0) should probably be updated as well.

```diff
- https://github.com/sveltejs/eslint-plugin-svelte/blob/eslint-plugin-svelte%403.0.0/README.md#versioning-policy
+ https://github.com/sveltejs/eslint-plugin-svelte/blob/eslint-plugin-svelte%403.0.2/README.md#versioning-policy
```