### PR TITLE
fix: align required Node version with ESLint

### DIFF
--- a/.changeset/angry-books-go.md
+++ b/.changeset/angry-books-go.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: align required Node version with ESLint

--- a/packages/eslint-plugin-svelte/package.json
+++ b/packages/eslint-plugin-svelte/package.json
@@ -65,7 +65,7 @@
     "postcss-load-config": "^3.1.4",
     "postcss-safe-parser": "^7.0.0",
     "semver": "^7.6.3",
-    "svelte-eslint-parser": "^1.0.0"
+    "svelte-eslint-parser": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/packages/eslint-plugin-svelte/package.json
+++ b/packages/eslint-plugin-svelte/package.json
@@ -8,7 +8,7 @@
   "funding": "https://github.com/sponsors/ota-meshi",
   "license": "MIT",
   "engines": {
-    "node": "^18.20.4 || ^20.18.0 || >=22.10.0"
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1114

⚠️ We need to release https://github.com/sveltejs/svelte-eslint-parser/pull/681 first.