### PR TITLE
fix: resolve false positives on nested objects in `no-unused-props` rule

### DIFF
--- a/.changeset/fuzzy-ads-join.md
+++ b/.changeset/fuzzy-ads-join.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: resolve false positives on nested objects in `no-unused-props` rule

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
@@ -319,7 +319,7 @@ export default createRule('no-unused-props', {
 						.filter((v): v is TSESTree.Identifier => v.type === 'Identifier');
 					for (const identifier of identifiers) {
 						const paths = getUsedNestedPropertyNames(identifier);
-						usedPaths.push(...paths);
+						usedPaths.push(...paths.map((path) => [identifier.name, ...path]));
 					}
 				} else if (node.id.type === 'Identifier') {
 					usedPaths = getUsedNestedPropertyNames(node.id);

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/ts-basic-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/ts-basic-input.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	// fix: https://github.com/sveltejs/eslint-plugin-svelte/issues/1028#issuecomment-2728101827
+	type Prop = {
+		value: string;
+		value2: string;
+	};
+
+	interface Props {
+		myObjectProp: Prop;
+	}
+
+	const { myObjectProp }: Props = $props();
+</script>
+
+<p>{myObjectProp.value} {myObjectProp.value2}</p>


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/pull/1061#issuecomment-2728592702
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1028#issuecomment-2728101827