### PR TITLE
fix: correct detection of externally defined types in `no-unused-props` rule

### DIFF
--- a/.changeset/plain-chairs-tie.md
+++ b/.changeset/plain-chairs-tie.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: correct detection of externally defined types in `no-unused-props` rule

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/ignore-external-type-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/ignore-external-type-errors.yaml
@@ -1,4 +1,4 @@
 - message: "'child2' is an unused Props property."
-  line: 10
+  line: 9
   column: 6
   suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/ignore-external-type-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/ignore-external-type-errors.yaml
@@ -1,0 +1,4 @@
+- message: "'child2' is an unused Props property."
+  line: 10
+  column: 6
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/ignore-external-type-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/ignore-external-type-input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import type { FooDTO } from './shared-types';
+
+	interface Props extends FooDTO {
+		child1: string;
+		child2: number;
+	}
+
+	let { foo, child1 }: Props = $props();
+</script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/imported-type-check-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/imported-type-check-errors.yaml
@@ -1,6 +1,4 @@
 - message: "'name' is an unused Props property."
   line: 6
   column: 6
-  endLine: 6
-  endColumn: 20
   suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/shared-types.ts
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/shared-types.ts
@@ -1,3 +1,14 @@
 export interface BaseProps {
 	name: string;
 }
+
+export interface FooDTO {
+	foo: string;
+	bar: number;
+	baz: BazDTO;
+}
+
+interface BazDTO {
+	qux: string;
+	quux: number;
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/ignore-external-type-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/ignore-external-type-input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import type { FooDTO } from './shared-types';
+
+	interface Props extends FooDTO {
+		child1: string;
+		child2: number;
+	}
+
+	let { foo, child1, child2 }: Props = $props();
+</script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/shared-types.ts
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/shared-types.ts
@@ -1,3 +1,14 @@
 export interface BaseProps {
 	name: string;
 }
+
+export interface FooDTO {
+	foo: string;
+	bar: number;
+	baz: BazDTO;
+}
+
+interface BazDTO {
+	qux: string;
+	quux: number;
+}


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1133
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1136