### PR TITLE
fix: stop reporting child properties in `no-unused-props` when the parent object itself is used

### DIFF
--- a/.changeset/floppy-symbols-sing.md
+++ b/.changeset/floppy-symbols-sing.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: stop reporting child properties in `no-unused-props` when the parent object itself is used

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/nested-props2-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/nested-props2-input.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import GenericPopout from './GenericPopout.svelte';
+
+	let {
+		position
+	}: {
+		position: {
+			x: number;
+			y: number;
+		};
+	} = $props();
+</script>
+
+<GenericPopout {position}>Test</GenericPopout>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/nested-props3-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/nested-props3-input.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import GenericPopout from './GenericPopout.svelte';
+
+	let {
+		wrapper
+	}: {
+		wrapper: {
+			position: {
+				x: number;
+				y: number;
+			};
+		};
+	} = $props();
+</script>
+
+<GenericPopout position={wrapper.position}>Test</GenericPopout>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/nested-props4-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/nested-props4-input.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import GenericPopout from './GenericPopout.svelte';
+
+	let {
+		wrapper
+	}: {
+		wrapper: {
+			position: {
+				x: number;
+				y: number;
+			};
+		};
+	} = $props();
+</script>
+
+<GenericPopout x={wrapper.position.x}>Test</GenericPopout>
+<GenericPopout position={wrapper.position}>Test</GenericPopout>


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1142