### PR TITLE
test: account for js output in test cases

### DIFF
--- a/packages/eslint-plugin-svelte/tests/utils/utils.ts
+++ b/packages/eslint-plugin-svelte/tests/utils/utils.ts
@@ -126,15 +126,19 @@ export function loadTestCases(
 		.map((inputFile) => {
 			const config = getConfig(ruleName, inputFile);
 			const errorFile = inputFile.replace(/(input|\+.+)\.[a-z]+$/u, 'errors.yaml');
-			const outputFile = inputFile.replace(/(input|\+.+)\.[a-z]+$/u, 'output.svelte');
+			const outputExt = path.extname(inputFile);
+			const outputFile = inputFile.replace(
+				/(input|\+.+)\.[a-z]+$/u,
+				`output.${outputExt.slice(1)}`
+			);
 
 			if (!fs.existsSync(errorFile)) {
-				writeFixtures(ruleName, inputFile);
+				writeFixtures(ruleName, inputFile, outputFile);
 			} else if (
 				// eslint-disable-next-line no-process-env -- tool
 				process.env.UPDATE_FIXTURES
 			) {
-				writeFixtures(ruleName, inputFile, { force: true });
+				writeFixtures(ruleName, inputFile, outputFile, { force: true });
 			}
 			const errors = fs.readFileSync(errorFile, 'utf8');
 			config.errors = parseYaml(errors);
@@ -151,7 +155,7 @@ export function loadTestCases(
 				try {
 					output = fs.readFileSync(outputFile, 'utf8');
 				} catch (_e) {
-					writeFixtures(ruleName, inputFile);
+					writeFixtures(ruleName, inputFile, outputFile);
 					output = fs.readFileSync(outputFile, 'utf8');
 				}
 				config.output = output === config.code ? null : output;
@@ -213,10 +217,14 @@ function applySuggestion(code: string, suggestion: LinterType.LintSuggestion) {
 	return `${code.slice(0, fix.range[0])}${fix.text}${code.slice(fix.range[1])}`;
 }
 
-function writeFixtures(ruleName: string, inputFile: string, { force }: { force?: boolean } = {}) {
+function writeFixtures(
+	ruleName: string,
+	inputFile: string,
+	outputFile: string,
+	{ force }: { force?: boolean } = {}
+) {
 	const linter = new Linter();
 	const errorFile = inputFile.replace(/(input|\+.+)\.[a-z]+$/u, 'errors.yaml');
-	const outputFile = inputFile.replace(/(input|\+.+)\.[a-z]+$/u, 'output.svelte');
 
 	const config = getConfig(ruleName, inputFile);
 


### PR DESCRIPTION
Currently, we assume test output will always be a `.svelte` file. This isn't always true (e.g. for the derived input/output rule).

This changes the util to basically use the extension of the input in the output, and avoids re-computing it by passing it in.