### PR TITLE
chore: use `context.sourceCode` instead of compat

### DIFF
--- a/.changeset/happy-donuts-fold.md
+++ b/.changeset/happy-donuts-fold.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+Use `context.sourceCode` directly rather than a compatibility helper.

--- a/.changeset/happy-donuts-fold.md
+++ b/.changeset/happy-donuts-fold.md
@@ -2,4 +2,4 @@
 'eslint-plugin-svelte': patch
 ---
 
-Use `context.sourceCode` directly rather than a compatibility helper.
+chore: use `context.sourceCode` directly rather than a compatibility helper.

--- a/packages/eslint-plugin-svelte/eslint.config.mjs
+++ b/packages/eslint-plugin-svelte/eslint.config.mjs
@@ -70,7 +70,7 @@ const config = [
 			],
 			'no-restricted-properties': [
 				'error',
-				{ object: 'context', property: 'getSourceCode', message: 'Use src/utils/compat.ts' },
+				{ object: 'context', property: 'getSourceCode', message: 'Use `context.sourceCode`' },
 				{ object: 'context', property: 'getFilename', message: 'Use src/utils/compat.ts' },
 				{
 					object: 'context',

--- a/packages/eslint-plugin-svelte/src/rules/@typescript-eslint/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin-svelte/src/rules/@typescript-eslint/no-unnecessary-condition.ts
@@ -22,7 +22,6 @@ import {
 	isTupleType
 } from '../../utils/ts-utils/index.js';
 import type { TS, TSTools } from '../../utils/ts-utils/index.js';
-import { getSourceCode } from '../../utils/compat.js';
 
 /**
  * Returns all types of a union type or an array containing `type` itself if it's no union type.
@@ -157,7 +156,7 @@ export default createRule('@typescript-eslint/no-unnecessary-condition', {
 
 		const { service, ts } = tools;
 		const checker = service.program.getTypeChecker();
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		const compilerOptions = service.program.getCompilerOptions();
 		const isStrictNullChecks = compilerOptions.strict
 			? compilerOptions.strictNullChecks !== false

--- a/packages/eslint-plugin-svelte/src/rules/block-lang.ts
+++ b/packages/eslint-plugin-svelte/src/rules/block-lang.ts
@@ -1,7 +1,6 @@
 import { createRule } from '../utils/index.js';
 import { findAttribute, getLangValue } from '../utils/ast-utils.js';
 import type { SvelteScriptElement, SvelteStyleElement } from 'svelte-eslint-parser/lib/ast';
-import { getSourceCode } from '../utils/compat.js';
 import type { SuggestionReportDescriptor, SourceCode } from '../types.js';
 
 export default createRule('block-lang', {
@@ -59,7 +58,7 @@ export default createRule('block-lang', {
 		hasSuggestions: true
 	},
 	create(context) {
-		if (!getSourceCode(context).parserServices.isSvelte) {
+		if (!context.sourceCode.parserServices.isSvelte) {
 			return {};
 		}
 		const enforceScriptPresent: boolean = context.options[0]?.enforceScriptPresent ?? false;
@@ -91,7 +90,7 @@ export default createRule('block-lang', {
 						message: `The <script> block should be present and its lang attribute should be ${prettyPrintLangs(
 							allowedScriptLangs
 						)}.`,
-						suggest: buildAddLangSuggestions(allowedScriptLangs, 'script', getSourceCode(context))
+						suggest: buildAddLangSuggestions(allowedScriptLangs, 'script', context.sourceCode)
 					});
 				}
 				for (const scriptNode of scriptNodes) {
@@ -106,7 +105,7 @@ export default createRule('block-lang', {
 					}
 				}
 				if (styleNodes.length === 0 && enforceStylePresent) {
-					const sourceCode = getSourceCode(context);
+					const sourceCode = context.sourceCode;
 					context.report({
 						loc: { line: 1, column: 1 },
 						message: `The <style> block should be present and its lang attribute should be ${prettyPrintLangs(

--- a/packages/eslint-plugin-svelte/src/rules/comment-directive.ts
+++ b/packages/eslint-plugin-svelte/src/rules/comment-directive.ts
@@ -2,7 +2,7 @@ import type { AST } from 'svelte-eslint-parser';
 import { getShared } from '../shared/index.js';
 import type { CommentDirectives } from '../shared/comment-directives.js';
 import { createRule } from '../utils/index.js';
-import { getFilename, getSourceCode } from '../utils/compat.js';
+import { getFilename } from '../utils/compat.js';
 
 type RuleAndLocation = {
 	ruleId: string;
@@ -63,7 +63,7 @@ export default createRule('comment-directive', {
 			reportUnusedDisableDirectives
 		});
 
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Parse a given comment.

--- a/packages/eslint-plugin-svelte/src/rules/consistent-selector-style.ts
+++ b/packages/eslint-plugin-svelte/src/rules/consistent-selector-style.ts
@@ -7,7 +7,6 @@ import type {
 	Tag as SelectorTag
 } from 'postcss-selector-parser';
 import { findClassesInAttribute } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 import { createRule } from '../utils/index.js';
 
 export default createRule('consistent-selector-style', {
@@ -48,7 +47,7 @@ export default createRule('consistent-selector-style', {
 		type: 'suggestion'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		if (
 			!sourceCode.parserServices.isSvelte ||
 			sourceCode.parserServices.getStyleSelectorAST === undefined ||

--- a/packages/eslint-plugin-svelte/src/rules/first-attribute-linebreak.ts
+++ b/packages/eslint-plugin-svelte/src/rules/first-attribute-linebreak.ts
@@ -1,6 +1,5 @@
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('first-attribute-linebreak', {
 	meta: {
@@ -30,7 +29,7 @@ export default createRule('first-attribute-linebreak', {
 	create(context) {
 		const multiline: 'below' | 'beside' = context.options[0]?.multiline || 'below';
 		const singleline: 'below' | 'beside' = context.options[0]?.singleline || 'beside';
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Report attribute

--- a/packages/eslint-plugin-svelte/src/rules/html-closing-bracket-new-line.ts
+++ b/packages/eslint-plugin-svelte/src/rules/html-closing-bracket-new-line.ts
@@ -1,6 +1,5 @@
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 import type { SourceCode } from '../types.js';
 
 type ExpectedNode = AST.SvelteStartTag | AST.SvelteEndTag;
@@ -123,7 +122,7 @@ export default createRule('html-closing-bracket-new-line', {
 		options.singleline ??= 'never';
 		options.multiline ??= 'always';
 
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		return {
 			'SvelteStartTag, SvelteEndTag'(node: ExpectedNode) {

--- a/packages/eslint-plugin-svelte/src/rules/html-closing-bracket-spacing.ts
+++ b/packages/eslint-plugin-svelte/src/rules/html-closing-bracket-spacing.ts
@@ -40,7 +40,7 @@ export default createRule('html-closing-bracket-spacing', {
 			selfClosingTag: 'always',
 			...ctx.options[0]
 		};
-		const src = ctx.getSourceCode();
+		const src = ctx.sourceCode;
 
 		/**
 		 * Returns true if string contains newline characters

--- a/packages/eslint-plugin-svelte/src/rules/html-quotes.ts
+++ b/packages/eslint-plugin-svelte/src/rules/html-quotes.ts
@@ -3,7 +3,6 @@ import { createRule } from '../utils/index.js';
 import type { QuoteAndRange } from '../utils/ast-utils.js';
 import { getMustacheTokens } from '../utils/ast-utils.js';
 import { getAttributeValueQuoteAndRange } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 const QUOTE_CHARS = {
 	double: '"',
@@ -49,7 +48,7 @@ export default createRule('html-quotes', {
 		type: 'layout' // "problem",
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		const preferQuote: 'double' | 'single' = context.options[0]?.prefer ?? 'double';
 		const dynamicQuote = context.options[0]?.dynamic?.quoted ? preferQuote : 'unquoted';
 		const avoidInvalidUnquotedInHTML = Boolean(

--- a/packages/eslint-plugin-svelte/src/rules/html-self-closing.ts
+++ b/packages/eslint-plugin-svelte/src/rules/html-self-closing.ts
@@ -6,7 +6,6 @@ import {
 	isSvgElement,
 	isMathMLElement
 } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 const TYPE_MESSAGES = {
 	normal: 'HTML elements',
@@ -160,7 +159,7 @@ export default createRule('html-self-closing', {
 			context.report({
 				node,
 				loc: {
-					start: getSourceCode(context).getLocFromIndex(
+					start: context.sourceCode.getLocFromIndex(
 						node.startTag.range[1] - (node.startTag.selfClosing ? 2 : 1)
 					),
 					end: node.loc.end

--- a/packages/eslint-plugin-svelte/src/rules/indent-helpers/index.ts
+++ b/packages/eslint-plugin-svelte/src/rules/indent-helpers/index.ts
@@ -8,7 +8,7 @@ import { isCommentToken } from '@eslint-community/eslint-utils';
 import type { AnyToken, IndentOptions } from './commons.js';
 import type { OffsetCalculator } from './offset-context.js';
 import { OffsetContext } from './offset-context.js';
-import { getFilename, getSourceCode } from '../../utils/compat.js';
+import { getFilename } from '../../utils/compat.js';
 
 type IndentUserOptions = {
 	indent?: number | 'tab';
@@ -81,7 +81,7 @@ export function defineVisitor(
 	if (!getFilename(context).endsWith('.svelte')) return {};
 
 	const options = parseOptions(context.options[0] || {}, defaultOptions);
-	const sourceCode = getSourceCode(context);
+	const sourceCode = context.sourceCode;
 	const offsets = new OffsetContext({ sourceCode, options });
 
 	/**

--- a/packages/eslint-plugin-svelte/src/rules/infinite-reactive-loop.ts
+++ b/packages/eslint-plugin-svelte/src/rules/infinite-reactive-loop.ts
@@ -5,7 +5,6 @@ import { createRule } from '../utils/index.js';
 import type { RuleContext } from '../types.js';
 import { findVariable } from '../utils/ast-utils.js';
 import { traverseNodes } from 'svelte-eslint-parser';
-import { getSourceCode } from '../utils/compat.js';
 
 /**
  * Get usage of `tick`
@@ -13,7 +12,7 @@ import { getSourceCode } from '../utils/compat.js';
 function extractTickReferences(
 	context: RuleContext
 ): { node: TSESTree.CallExpression; name: string }[] {
-	const referenceTracker = new ReferenceTracker(getSourceCode(context).scopeManager.globalScope!);
+	const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 	const a = referenceTracker.iterateEsmReferences({
 		svelte: {
 			[ReferenceTracker.ESM]: true,
@@ -36,7 +35,7 @@ function extractTickReferences(
 function extractTaskReferences(
 	context: RuleContext
 ): { node: TSESTree.CallExpression; name: string }[] {
-	const referenceTracker = new ReferenceTracker(getSourceCode(context).scopeManager.globalScope!);
+	const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 	const a = referenceTracker.iterateGlobalReferences({
 		setTimeout: { [ReferenceTracker.CALL]: true },
 		setInterval: { [ReferenceTracker.CALL]: true },
@@ -123,7 +122,7 @@ function isPromiseThenOrCatchBody(node: TSESTree.Node): boolean {
  * Get all reactive variable reference.
  */
 function getReactiveVariableReferences(context: RuleContext) {
-	const scopeManager = getSourceCode(context).scopeManager;
+	const scopeManager = context.sourceCode.scopeManager;
 	// Find the top-level (module or global) scope.
 	// Any variable defined at the top-level (module scope or global scope) can be made reactive.
 	const toplevelScope =

--- a/packages/eslint-plugin-svelte/src/rules/max-attributes-per-line.ts
+++ b/packages/eslint-plugin-svelte/src/rules/max-attributes-per-line.ts
@@ -1,6 +1,5 @@
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 /**
  * Check whether the component is declared in a single line or not.
@@ -58,7 +57,7 @@ export default createRule('max-attributes-per-line', {
 	create(context) {
 		const multilineMaximum = context.options[0]?.multiline ?? 1;
 		const singlelineMaximum = context.options[0]?.singleline ?? 1;
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Report attributes

--- a/packages/eslint-plugin-svelte/src/rules/mustache-spacing.ts
+++ b/packages/eslint-plugin-svelte/src/rules/mustache-spacing.ts
@@ -2,7 +2,6 @@ import type { AST } from 'svelte-eslint-parser';
 import { isClosingBraceToken, isOpeningBraceToken } from '@eslint-community/eslint-utils';
 import { createRule } from '../utils/index.js';
 import { getMustacheTokens } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 type DeepPartial<T> = {
 	[P in keyof T]?: DeepPartial<T[P]>;
 };
@@ -74,7 +73,7 @@ export default createRule('mustache-spacing', {
 	},
 	create(context) {
 		const options = parseOptions(context.options[0]);
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		function verifyBraces(
 			openingBrace: AST.Token | AST.Comment,

--- a/packages/eslint-plugin-svelte/src/rules/no-dupe-else-if-blocks.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-dupe-else-if-blocks.ts
@@ -2,7 +2,6 @@ import type { AST } from 'svelte-eslint-parser';
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
 import { equalTokens } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -82,7 +81,7 @@ export default createRule('no-dupe-else-if-blocks', {
 		type: 'problem' // "problem",
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Determines whether the two given nodes are considered to be equal. In particular, given that the nodes

--- a/packages/eslint-plugin-svelte/src/rules/no-dupe-on-directives.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-dupe-on-directives.ts
@@ -2,7 +2,6 @@ import type { AST } from 'svelte-eslint-parser';
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
 import { equalTokens } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-dupe-on-directives', {
 	meta: {
@@ -19,7 +18,7 @@ export default createRule('no-dupe-on-directives', {
 		type: 'problem'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		const directiveDataMap = new Map<
 			string, // event type

--- a/packages/eslint-plugin-svelte/src/rules/no-dupe-use-directives.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-dupe-use-directives.ts
@@ -2,7 +2,6 @@ import type { AST } from 'svelte-eslint-parser';
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
 import { equalTokens, getAttributeKeyText } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-dupe-use-directives', {
 	meta: {
@@ -19,7 +18,7 @@ export default createRule('no-dupe-use-directives', {
 		type: 'problem'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		const directiveDataMap = new Map<
 			string, // key text

--- a/packages/eslint-plugin-svelte/src/rules/no-dynamic-slot-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-dynamic-slot-name.ts
@@ -6,7 +6,6 @@ import {
 	getAttributeValueQuoteAndRange,
 	getStringIfConstant
 } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-dynamic-slot-name', {
 	meta: {
@@ -28,7 +27,7 @@ export default createRule('no-dynamic-slot-name', {
 		}
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		return {
 			"SvelteElement[name.name='slot'] > SvelteStartTag.startTag > SvelteAttribute[key.name='name']"(
 				node: AST.SvelteAttribute

--- a/packages/eslint-plugin-svelte/src/rules/no-extra-reactive-curlies.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-extra-reactive-curlies.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-extra-reactive-curlies', {
 	meta: {
@@ -24,7 +23,7 @@ export default createRule('no-extra-reactive-curlies', {
 			[`SvelteReactiveStatement > BlockStatement[body.length=1]`]: (
 				node: TSESTree.BlockStatement
 			) => {
-				const source = getSourceCode(context);
+				const source = context.sourceCode;
 
 				return context.report({
 					node,

--- a/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts
@@ -23,9 +23,7 @@ export default createRule('no-goto-without-base', {
 	create(context) {
 		return {
 			Program() {
-				const referenceTracker = new ReferenceTracker(
-					context.sourceCode.scopeManager.globalScope!
-				);
+				const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 				const basePathNames = extractBasePathReferences(referenceTracker, context);
 				for (const gotoCall of extractGotoReferences(referenceTracker)) {
 					if (gotoCall.arguments.length < 1) {

--- a/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
 import { ReferenceTracker } from '@eslint-community/eslint-utils';
-import { getSourceCode } from '../utils/compat.js';
 import { findVariable } from '../utils/ast-utils.js';
 import type { RuleContext } from '../types.js';
 
@@ -25,7 +24,7 @@ export default createRule('no-goto-without-base', {
 		return {
 			Program() {
 				const referenceTracker = new ReferenceTracker(
-					getSourceCode(context).scopeManager.globalScope!
+					context.sourceCode.scopeManager.globalScope!
 				);
 				const basePathNames = extractBasePathReferences(referenceTracker, context);
 				for (const gotoCall of extractGotoReferences(referenceTracker)) {

--- a/packages/eslint-plugin-svelte/src/rules/no-immutable-reactive-statements.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-immutable-reactive-statements.ts
@@ -3,7 +3,6 @@ import { createRule } from '../utils/index.js';
 import type { Scope, Variable, Reference, Definition } from '@typescript-eslint/scope-manager';
 import type { TSESTree } from '@typescript-eslint/types';
 import { findVariable, iterateIdentifiers } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-immutable-reactive-statements', {
 	meta: {
@@ -20,7 +19,7 @@ export default createRule('no-immutable-reactive-statements', {
 		type: 'suggestion'
 	},
 	create(context) {
-		const scopeManager = getSourceCode(context).scopeManager;
+		const scopeManager = context.sourceCode.scopeManager;
 		const globalScope = scopeManager.globalScope;
 		const toplevelScope =
 			globalScope?.childScopes.find((scope) => scope.type === 'module') || globalScope;

--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-base.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-base.ts
@@ -47,9 +47,7 @@ export default createRule('no-navigation-without-base', {
 		let basePathNames: Set<TSESTree.Identifier> = new Set<TSESTree.Identifier>();
 		return {
 			Program() {
-				const referenceTracker = new ReferenceTracker(
-					context.sourceCode.scopeManager.globalScope!
-				);
+				const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 				basePathNames = extractBasePathReferences(referenceTracker, context);
 				const {
 					goto: gotoCalls,

--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-base.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-base.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
 import { ReferenceTracker } from '@eslint-community/eslint-utils';
-import { getSourceCode } from '../utils/compat.js';
 import { findVariable } from '../utils/ast-utils.js';
 import type { RuleContext } from '../types.js';
 import type { SvelteLiteral } from 'svelte-eslint-parser/lib/ast';
@@ -49,7 +48,7 @@ export default createRule('no-navigation-without-base', {
 		return {
 			Program() {
 				const referenceTracker = new ReferenceTracker(
-					getSourceCode(context).scopeManager.globalScope!
+					context.sourceCode.scopeManager.globalScope!
 				);
 				basePathNames = extractBasePathReferences(referenceTracker, context);
 				const {

--- a/packages/eslint-plugin-svelte/src/rules/no-reactive-functions.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-reactive-functions.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-reactive-functions', {
 	meta: {
@@ -40,7 +39,7 @@ export default createRule('no-reactive-functions', {
 					return false;
 				}
 
-				const source = getSourceCode(context);
+				const source = context.sourceCode;
 
 				return context.report({
 					node: parent,

--- a/packages/eslint-plugin-svelte/src/rules/no-reactive-literals.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-reactive-literals.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-reactive-literals', {
 	meta: {
@@ -46,7 +45,7 @@ export default createRule('no-reactive-literals', {
 					return false;
 				}
 
-				const source = getSourceCode(context);
+				const source = context.sourceCode;
 
 				return context.report({
 					node: parent,

--- a/packages/eslint-plugin-svelte/src/rules/no-reactive-reassign.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-reactive-reassign.ts
@@ -2,7 +2,6 @@ import type { TSESTree } from '@typescript-eslint/types';
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
 import { getPropertyName } from '@eslint-community/eslint-utils';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-reactive-reassign', {
 	meta: {
@@ -39,7 +38,7 @@ export default createRule('no-reactive-reassign', {
 	},
 	create(context) {
 		const props = context.options[0]?.props !== false; // default true
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		const scopeManager = sourceCode.scopeManager;
 		const globalScope = scopeManager.globalScope;
 		const toplevelScope =

--- a/packages/eslint-plugin-svelte/src/rules/no-spaces-around-equal-signs-in-attribute.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-spaces-around-equal-signs-in-attribute.ts
@@ -17,7 +17,7 @@ export default createRule('no-spaces-around-equal-signs-in-attribute', {
 		type: 'layout'
 	},
 	create(ctx) {
-		const source = ctx.getSourceCode();
+		const source = ctx.sourceCode;
 
 		/**
 		 * Returns source text between attribute key and value, and range of that source

--- a/packages/eslint-plugin-svelte/src/rules/no-trailing-spaces.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-trailing-spaces.ts
@@ -1,6 +1,5 @@
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-trailing-spaces', {
 	meta: {
@@ -33,7 +32,7 @@ export default createRule('no-trailing-spaces', {
 		const skipBlankLines = options?.skipBlankLines || false;
 		const ignoreComments = options?.ignoreComments || false;
 
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		const ignoreLineNumbers = new Set<number>();
 		if (ignoreComments) {

--- a/packages/eslint-plugin-svelte/src/rules/no-unnecessary-state-wrap.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unnecessary-state-wrap.ts
@@ -79,9 +79,7 @@ export default createRule('no-unnecessary-state-wrap', {
 		});
 
 		function isReassigned(identifier: TSESTree.Identifier): boolean {
-			const variable = context.sourceCode.scopeManager.getDeclaredVariables(
-				identifier.parent
-			)[0];
+			const variable = context.sourceCode.scopeManager.getDeclaredVariables(identifier.parent)[0];
 			return variable.references.some((ref) => {
 				return ref.isWrite() && ref.identifier !== identifier;
 			});

--- a/packages/eslint-plugin-svelte/src/rules/no-unnecessary-state-wrap.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unnecessary-state-wrap.ts
@@ -1,5 +1,4 @@
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 import { ReferenceTracker } from '@eslint-community/eslint-utils';
 import type { TSESTree } from '@typescript-eslint/types';
 
@@ -55,7 +54,7 @@ export default createRule('no-unnecessary-state-wrap', {
 		const additionalReactiveClasses = options.additionalReactiveClasses ?? [];
 		const allowReassign = options.allowReassign ?? false;
 
-		const referenceTracker = new ReferenceTracker(getSourceCode(context).scopeManager.globalScope!);
+		const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 		const traceMap: Record<string, Record<string, boolean>> = {};
 		for (const reactiveClass of REACTIVE_CLASSES) {
 			traceMap[reactiveClass] = {
@@ -80,7 +79,7 @@ export default createRule('no-unnecessary-state-wrap', {
 		});
 
 		function isReassigned(identifier: TSESTree.Identifier): boolean {
-			const variable = getSourceCode(context).scopeManager.getDeclaredVariables(
+			const variable = context.sourceCode.scopeManager.getDeclaredVariables(
 				identifier.parent
 			)[0];
 			return variable.references.some((ref) => {
@@ -108,7 +107,7 @@ export default createRule('no-unnecessary-state-wrap', {
 					{
 						messageId: 'suggestRemoveStateWrap',
 						fix(fixer) {
-							return fixer.replaceText(stateNode, getSourceCode(context).getText(targetNode));
+							return fixer.replaceText(stateNode, context.sourceCode.getText(targetNode));
 						}
 					}
 				]

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -3,7 +3,6 @@ import type { AST } from 'svelte-eslint-parser';
 import type { AnyNode } from 'postcss';
 import type { Node as SelectorNode } from 'postcss-selector-parser';
 import { findClassesInAttribute } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 import type { SourceCode } from '../types.js';
 
 export default createRule('no-unused-class-name', {
@@ -31,7 +30,7 @@ export default createRule('no-unused-class-name', {
 		type: 'suggestion'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		if (!sourceCode.parserServices.isSvelte) {
 			return {};
 		}

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-svelte-ignore.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-svelte-ignore.ts
@@ -2,7 +2,6 @@ import { getSvelteCompileWarnings } from '../shared/svelte-compile-warns/index.j
 import { createRule } from '../utils/index.js';
 import type { IgnoreItem } from '../shared/svelte-compile-warns/ignore-comment.js';
 import { getSvelteIgnoreItems } from '../shared/svelte-compile-warns/ignore-comment.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('no-unused-svelte-ignore', {
 	meta: {
@@ -20,7 +19,7 @@ export default createRule('no-unused-svelte-ignore', {
 	},
 
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		if (!sourceCode.parserServices.isSvelte) {
 			return {};
 		}

--- a/packages/eslint-plugin-svelte/src/rules/no-useless-mustaches.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-useless-mustaches.ts
@@ -1,6 +1,5 @@
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
-import { getSourceCode } from '../utils/compat.js';
 
 /**
  * Strip quotes string
@@ -46,7 +45,7 @@ export default createRule('no-useless-mustaches', {
 		const opts = context.options[0] || {};
 		const ignoreIncludesComment = Boolean(opts.ignoreIncludesComment);
 		const ignoreStringEscape = Boolean(opts.ignoreStringEscape);
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Report if the value expression is string literals

--- a/packages/eslint-plugin-svelte/src/rules/prefer-class-directive.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-class-directive.ts
@@ -3,7 +3,6 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { createRule } from '../utils/index.js';
 import { getStringIfConstant, isHTMLElementLike, needParentheses } from '../utils/ast-utils.js';
 import type { Rule } from 'eslint';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('prefer-class-directive', {
 	meta: {
@@ -29,7 +28,7 @@ export default createRule('prefer-class-directive', {
 		type: 'suggestion'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		const preferEmpty = context.options[0]?.prefer !== 'always';
 
 		type Expr = {

--- a/packages/eslint-plugin-svelte/src/rules/prefer-destructured-store-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-destructured-store-props.ts
@@ -5,7 +5,6 @@ import { keyword } from 'esutils';
 import type { SuggestionReportDescriptor } from '../types.js';
 import { createRule } from '../utils/index.js';
 import { findAttribute, isExpressionIdentifier, findVariable } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 type StoreMemberExpression = TSESTree.MemberExpression & {
 	object: TSESTree.Identifier & { name: string };
@@ -115,7 +114,7 @@ export default createRule('prefer-destructured-store-props', {
 
 		/** Checks whether the given name is already defined as a variable. */
 		function hasTopLevelVariable(name: string) {
-			const scopeManager = getSourceCode(context).scopeManager;
+			const scopeManager = context.sourceCode.scopeManager;
 			if (scopeManager.globalScope?.set.has(name)) {
 				return true;
 			}
@@ -252,7 +251,7 @@ export default createRule('prefer-destructured-store-props', {
 							store,
 							property: !node.computed
 								? node.property.name
-								: getSourceCode(context).getText(node.property).replace(/\s+/g, ' ')
+								: context.sourceCode.getText(node.property).replace(/\s+/g, ' ')
 						},
 
 						suggest

--- a/packages/eslint-plugin-svelte/src/rules/prefer-style-directive.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-style-directive.ts
@@ -9,7 +9,6 @@ import type {
 import { parseStyleAttributeValue } from '../utils/css-utils/index.js';
 import type { RuleFixer } from '../types.js';
 import { isHTMLElementLike } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 /** Checks wether the given node is string literal or not  */
 function isStringLiteral(node: TSESTree.Expression): node is TSESTree.StringLiteral {
@@ -32,7 +31,7 @@ export default createRule('prefer-style-directive', {
 		type: 'suggestion'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Process for `style=" ... "`

--- a/packages/eslint-plugin-svelte/src/rules/reference-helpers/svelte-store.ts
+++ b/packages/eslint-plugin-svelte/src/rules/reference-helpers/svelte-store.ts
@@ -5,7 +5,6 @@ import type { RuleContext } from '../../types.js';
 import type { TS, TSTools } from '../../utils/ts-utils/index.js';
 import { getTypeScriptTools } from '../../utils/ts-utils/index.js';
 import { findVariable, getParent } from '../../utils/ast-utils.js';
-import { getSourceCode } from '../../utils/compat.js';
 
 type StoreName = 'writable' | 'readable' | 'derived';
 
@@ -14,7 +13,7 @@ export function* extractStoreReferences(
 	context: RuleContext,
 	storeNames: StoreName[] = ['writable', 'readable', 'derived']
 ): Generator<{ node: TSESTree.CallExpression; name: string }, void> {
-	const referenceTracker = new ReferenceTracker(getSourceCode(context).scopeManager.globalScope!);
+	const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 	for (const { node, path } of referenceTracker.iterateEsmReferences({
 		'svelte/store': {
 			[ReferenceTracker.ESM]: true,

--- a/packages/eslint-plugin-svelte/src/rules/require-event-dispatcher-types.ts
+++ b/packages/eslint-plugin-svelte/src/rules/require-event-dispatcher-types.ts
@@ -2,7 +2,6 @@ import { ReferenceTracker } from '@eslint-community/eslint-utils';
 import { createRule } from '../utils/index.js';
 import { getLangValue } from '../utils/ast-utils.js';
 import type { TSESTree } from '@typescript-eslint/types';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('require-event-dispatcher-types', {
 	meta: {
@@ -36,7 +35,7 @@ export default createRule('require-event-dispatcher-types', {
 					return;
 				}
 				const referenceTracker = new ReferenceTracker(
-					getSourceCode(context).scopeManager.globalScope!
+					context.sourceCode.scopeManager.globalScope!
 				);
 				for (const { node: n } of referenceTracker.iterateEsmReferences({
 					svelte: {

--- a/packages/eslint-plugin-svelte/src/rules/require-event-dispatcher-types.ts
+++ b/packages/eslint-plugin-svelte/src/rules/require-event-dispatcher-types.ts
@@ -34,9 +34,7 @@ export default createRule('require-event-dispatcher-types', {
 				if (!isTs) {
 					return;
 				}
-				const referenceTracker = new ReferenceTracker(
-					context.sourceCode.scopeManager.globalScope!
-				);
+				const referenceTracker = new ReferenceTracker(context.sourceCode.scopeManager.globalScope!);
 				for (const { node: n } of referenceTracker.iterateEsmReferences({
 					svelte: {
 						[ReferenceTracker.ESM]: true,

--- a/packages/eslint-plugin-svelte/src/rules/require-store-callbacks-use-set-param.ts
+++ b/packages/eslint-plugin-svelte/src/rules/require-store-callbacks-use-set-param.ts
@@ -2,7 +2,6 @@ import { findVariableForReplacement } from '../utils/ast-utils.js';
 import type { SuggestionReportDescriptor } from '../types.js';
 import { createRule } from '../utils/index.js';
 import { extractStoreReferences } from './reference-helpers/svelte-store.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('require-store-callbacks-use-set-param', {
 	meta: {
@@ -53,7 +52,7 @@ export default createRule('require-store-callbacks-use-set-param', {
 									}
 								});
 							} else {
-								const token = getSourceCode(context).getTokenBefore(fn.body, {
+								const token = context.sourceCode.getTokenBefore(fn.body, {
 									filter: (token) => token.type === 'Punctuator' && token.value === '(',
 									includeComments: false
 								});

--- a/packages/eslint-plugin-svelte/src/rules/require-store-reactive-access.ts
+++ b/packages/eslint-plugin-svelte/src/rules/require-store-reactive-access.ts
@@ -2,7 +2,6 @@ import type { TSESTree } from '@typescript-eslint/types';
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
 import { createStoreChecker } from './reference-helpers/svelte-store.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('require-store-reactive-access', {
 	meta: {
@@ -21,7 +20,7 @@ export default createRule('require-store-reactive-access', {
 		type: 'problem'
 	},
 	create(context) {
-		if (!getSourceCode(context).parserServices.isSvelte) {
+		if (!context.sourceCode.parserServices.isSvelte) {
 			return {};
 		}
 		const isStore = createStoreChecker(context);

--- a/packages/eslint-plugin-svelte/src/rules/shorthand-attribute.ts
+++ b/packages/eslint-plugin-svelte/src/rules/shorthand-attribute.ts
@@ -1,6 +1,5 @@
 import { createRule } from '../utils/index.js';
 import { getAttributeValueQuoteAndRange } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('shorthand-attribute', {
 	meta: {
@@ -27,7 +26,7 @@ export default createRule('shorthand-attribute', {
 		type: 'layout'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		const always: boolean = context.options[0]?.prefer !== 'never';
 
 		return always

--- a/packages/eslint-plugin-svelte/src/rules/shorthand-directive.ts
+++ b/packages/eslint-plugin-svelte/src/rules/shorthand-directive.ts
@@ -1,7 +1,6 @@
 import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
 import { getAttributeValueQuoteAndRange } from '../utils/ast-utils.js';
-import { getSourceCode } from '../utils/compat.js';
 
 export default createRule('shorthand-directive', {
 	meta: {
@@ -28,7 +27,7 @@ export default createRule('shorthand-directive', {
 		type: 'layout'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		const always: boolean = context.options[0]?.prefer !== 'never';
 
 		/** Report for always */

--- a/packages/eslint-plugin-svelte/src/rules/sort-attributes.ts
+++ b/packages/eslint-plugin-svelte/src/rules/sort-attributes.ts
@@ -2,7 +2,6 @@ import type { AST } from 'svelte-eslint-parser';
 import { createRule } from '../utils/index.js';
 import { getAttributeKeyText } from '../utils/ast-utils.js';
 import { toRegExp } from '../utils/regexp.js';
-import { getSourceCode } from '../utils/compat.js';
 
 type UserOrderObjectOption = {
 	match: string | string[];
@@ -254,7 +253,7 @@ export default createRule('sort-attributes', {
 						attributes.indexOf(node)
 					);
 					const moveNodes = [node, ...previousNodes];
-					const sourceCode = getSourceCode(context);
+					const sourceCode = context.sourceCode;
 					return moveNodes.map((moveNode, index) => {
 						const text = sourceCode.getText(moveNode);
 						return fixer.replaceText(previousNodes[index] || node, text);

--- a/packages/eslint-plugin-svelte/src/rules/valid-compile.ts
+++ b/packages/eslint-plugin-svelte/src/rules/valid-compile.ts
@@ -1,7 +1,6 @@
 import { createRule } from '../utils/index.js';
 import type { SvelteCompileWarnings, Warning } from '../shared/svelte-compile-warns/index.js';
 import { getSvelteCompileWarnings } from '../shared/svelte-compile-warns/index.js';
-import { getSourceCode } from '../utils/compat.js';
 import type { Position } from 'svelte-eslint-parser/lib/ast/common.js';
 
 const ignores: string[] = ['missing-declaration'] as const;
@@ -45,7 +44,7 @@ export default createRule('valid-compile', {
 		type: 'problem'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		if (!sourceCode.parserServices.isSvelte) {
 			return {};
 		}

--- a/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
+++ b/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
@@ -1,5 +1,5 @@
 import { createRule } from '../utils/index.js';
-import { getCwd, getSourceCode } from '../utils/compat.js';
+import { getCwd } from '../utils/compat.js';
 
 export default createRule('valid-style-parse', {
 	meta: {
@@ -13,7 +13,7 @@ export default createRule('valid-style-parse', {
 		type: 'problem'
 	},
 	create(context) {
-		const sourceCode = getSourceCode(context);
+		const sourceCode = context.sourceCode;
 		if (!sourceCode.parserServices.isSvelte) {
 			return {};
 		}

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/extract-leading-comments.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/extract-leading-comments.ts
@@ -2,14 +2,13 @@ import { isOpeningParenToken } from '@eslint-community/eslint-utils';
 import type { AST } from 'svelte-eslint-parser';
 import type { RuleContext } from '../../types.js';
 import type { ASTNodeWithParent } from '../../types-for-node.js';
-import { getSourceCode } from '../../utils/compat.js';
 
 /** Extract comments */
 export function extractLeadingComments(
 	context: RuleContext,
 	node: ASTNodeWithParent
 ): (AST.Token | AST.Comment)[] {
-	const sourceCode = getSourceCode(context);
+	const sourceCode = context.sourceCode;
 	const beforeToken = sourceCode.getTokenBefore(node, {
 		includeComments: false,
 		filter(token) {

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/ignore-comment.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/ignore-comment.ts
@@ -1,6 +1,5 @@
 import type { AST } from 'svelte-eslint-parser';
 import type { RuleContext } from '../../types.js';
-import { getSourceCode } from '../../utils/compat.js';
 
 const SVELTE_IGNORE_PATTERN = /^\s*svelte-ignore/m;
 
@@ -34,7 +33,7 @@ export type IgnoreItem = {
 
 /** Extract all svelte-ignore comment items */
 export function getSvelteIgnoreItems(context: RuleContext): (IgnoreItem | IgnoreItemWithoutCode)[] {
-	const sourceCode = getSourceCode(context);
+	const sourceCode = context.sourceCode;
 
 	const ignoreComments: (IgnoreItem | IgnoreItemWithoutCode)[] = [];
 	for (const comment of sourceCode.getAllComments()) {

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/typescript.ts
@@ -3,7 +3,6 @@ import type typescript from 'typescript';
 import type { RuleContext } from '../../../types.js';
 import type { TransformResult } from './types.js';
 import { loadModule } from '../../../utils/load-module.js';
-import { getSourceCode } from '../../../utils/compat.js';
 
 type TS = typeof typescript;
 /**
@@ -31,7 +30,7 @@ export function transform(
 			reportDiagnostics: false,
 			compilerOptions: {
 				target:
-					getSourceCode(context).parserServices.program?.getCompilerOptions()?.target ||
+					context.sourceCode.parserServices.program?.getCompilerOptions()?.target ||
 					ts.ScriptTarget.ESNext,
 				module: ts.ModuleKind.ESNext,
 				importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Preserve,

--- a/packages/eslint-plugin-svelte/src/types.ts
+++ b/packages/eslint-plugin-svelte/src/types.ts
@@ -153,7 +153,7 @@ export type RuleContext = {
 
 	getScope(): Scope;
 
-	getSourceCode(): SourceCode;
+	sourceCode: SourceCode;
 
 	markVariableAsUsed(name: string): boolean;
 

--- a/packages/eslint-plugin-svelte/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-svelte/src/utils/ast-utils.ts
@@ -4,7 +4,6 @@ import type { Scope, Variable } from '@typescript-eslint/scope-manager';
 import type { AST as SvAST } from 'svelte-eslint-parser';
 import * as eslintUtils from '@eslint-community/eslint-utils';
 import { voidElements, svgElements, mathmlElements } from './element-types.js';
-import { getSourceCode } from './compat.js';
 
 /**
  * Checks whether or not the tokens of two given nodes are same.
@@ -270,7 +269,7 @@ export function* iterateIdentifiers(
  * Gets the scope for the current node
  */
 export function getScope(context: RuleContext, currentNode: TSESTree.Node): Scope {
-	const scopeManager = getSourceCode(context).scopeManager;
+	const scopeManager = context.sourceCode.scopeManager;
 
 	let node: TSESTree.Node | null = currentNode;
 	for (; node; node = node.parent || null) {
@@ -683,7 +682,7 @@ function getSimpleNameFromNode(
 		throw new Error('Rule context is required');
 	}
 
-	return getSourceCode(context).getText(node);
+	return context.sourceCode.getText(node);
 }
 
 /**

--- a/packages/eslint-plugin-svelte/src/utils/compat.ts
+++ b/packages/eslint-plugin-svelte/src/utils/compat.ts
@@ -1,20 +1,9 @@
 import {
-	getSourceCode as getSourceCodeBase,
 	getFilename as getFilenameBase,
 	getPhysicalFilename as getPhysicalFilenameBase,
 	getCwd as getCwdBase
 } from 'eslint-compat-utils';
-import type { RuleContext, SourceCode } from '../types.js';
-
-// export function getSourceCode(context: RuleContext): SourceCode;
-// export function getSourceCode(context: Rule.RuleContext): ESLintSourceCode;
-/**
- * Returns an extended instance of `context.sourceCode` or the result of `context.getSourceCode()`.
- * Extended instances can use new APIs such as `getScope(node)` even with old ESLint.
- */
-export function getSourceCode(context: RuleContext): SourceCode {
-	return getSourceCodeBase(context as never) as never;
-}
+import type { RuleContext } from '../types.js';
 
 /**
  * Gets the value of `context.filename`, but for older ESLint it returns the result of `context.getFilename()`.

--- a/packages/eslint-plugin-svelte/src/utils/css-utils/style-attribute.ts
+++ b/packages/eslint-plugin-svelte/src/utils/css-utils/style-attribute.ts
@@ -4,7 +4,6 @@ import Parser from './template-safe-parser.js';
 import type { Root, ChildNode, AnyNode } from 'postcss';
 import { Input } from 'postcss';
 import type { TSESTree } from '@typescript-eslint/types';
-import { getSourceCode } from '../compat.js';
 
 /** Parse for CSS */
 function safeParseCss(css: string): Root | null {
@@ -35,7 +34,7 @@ export function parseStyleAttributeValue(
 		return null;
 	}
 	const startOffset = node.value[0].range[0];
-	const sourceCode = getSourceCode(context);
+	const sourceCode = context.sourceCode;
 	const cssCode = node.value.map((value) => sourceCode.getText(value)).join('');
 	const root = safeParseCss(cssCode);
 	if (!root) {
@@ -213,7 +212,7 @@ function convertRoot<E extends SvelteStyleInterpolation>(
 			if (inlineStyles.has(node)) {
 				return inlineStyles.get(node) || null;
 			}
-			const sourceCode = getSourceCode(ctx.context);
+			const sourceCode = ctx.context.sourceCode;
 			inlineStyles.set(node, null);
 
 			let converted: SvelteStyleRoot<TSESTree.Expression> | null;
@@ -357,7 +356,7 @@ function convertRange(node: AnyNode, ctx: Ctx): AST.Range {
 /** convert range */
 function toLoc(range: AST.Range, ctx: Ctx): AST.SourceLocation {
 	return {
-		start: getSourceCode(ctx.context).getLocFromIndex(range[0]),
-		end: getSourceCode(ctx.context).getLocFromIndex(range[1])
+		start: ctx.context.sourceCode.getLocFromIndex(range[0]),
+		end: ctx.context.sourceCode.getLocFromIndex(range[1])
 	};
 }

--- a/packages/eslint-plugin-svelte/src/utils/load-module.ts
+++ b/packages/eslint-plugin-svelte/src/utils/load-module.ts
@@ -2,14 +2,14 @@ import type { AST } from 'svelte-eslint-parser';
 import Module from 'module';
 import path from 'path';
 import type { RuleContext } from '../types.js';
-import { getCwd, getFilename, getPhysicalFilename, getSourceCode } from './compat.js';
+import { getCwd, getFilename, getPhysicalFilename } from './compat.js';
 const cache = new WeakMap<AST.SvelteProgram, Record<string, unknown>>();
 const cache4b = new Map<string, unknown>();
 /**
  * Load module
  */
 export function loadModule<R>(context: RuleContext, name: string): R | null {
-	const key = getSourceCode(context).ast;
+	const key = context.sourceCode.ast;
 	let modules = cache.get(key);
 	if (!modules) {
 		modules = {};

--- a/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
+++ b/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { getPackageJsons } from './get-package-json.js';
 import { getNodeModule } from './get-node-module.js';
-import { getFilename, getSourceCode } from './compat.js';
+import { getFilename } from './compat.js';
 import { createCache } from './cache.js';
 import { VERSION as SVELTE_VERSION } from 'svelte/compiler';
 
@@ -149,7 +149,7 @@ function getSvelteKitContext(
 	const routes =
 		(
 			context.settings?.svelte?.kit?.files?.routes ??
-			getSourceCode(context).parserServices.svelteParseContext?.svelteConfig?.kit?.files?.routes
+			context.sourceCode.parserServices.svelteParseContext?.svelteConfig?.kit?.files?.routes
 		)?.replace(/^\//, '') ?? 'src/routes';
 	const projectRootDir = getProjectRootDir(getFilename(context)) ?? '';
 
@@ -286,7 +286,7 @@ function getProjectRootDir(filePath: string): string | null {
 const svelteContextCache = createCache<SvelteContext | null>();
 
 export function getSvelteContext(context: RuleContext): SvelteContext | null {
-	const { parserServices } = getSourceCode(context);
+	const { parserServices } = context.sourceCode;
 	const { svelteParseContext } = parserServices;
 	const filePath = getFilename(context);
 

--- a/packages/eslint-plugin-svelte/src/utils/ts-utils/index.ts
+++ b/packages/eslint-plugin-svelte/src/utils/ts-utils/index.ts
@@ -1,7 +1,6 @@
 import type { RuleContext, ASTNode } from '../../types.js';
 import type * as TS from 'typescript';
 import { loadModule } from '../load-module.js';
-import { getSourceCode } from '../compat.js';
 export type TypeScript = typeof TS;
 export type { TS };
 
@@ -23,7 +22,7 @@ export function getTypeScriptTools(context: RuleContext): TSTools | null {
 	if (!ts) {
 		return null;
 	}
-	const sourceCode = getSourceCode(context);
+	const sourceCode = context.sourceCode;
 	const { program, esTreeNodeToTSNodeMap, tsNodeToESTreeNodeMap } = sourceCode.parserServices;
 	if (!program || !esTreeNodeToTSNodeMap || !tsNodeToESTreeNodeMap) {
 		return null;


### PR DESCRIPTION
As of 3.x, we only support `8.57.1` and `>=9.0.0` of ESLint.

Both of these have `context.sourceCode` available, so we should no longer need the `getSourceCode` compat helper.

The helper does polyfill some missing methods but `8.57.1` seems to have all of those already.