### PR TITLE
chore: use `context.filename` and `context.physicalFilename`

### DIFF
--- a/.changeset/petite-impalas-reply.md
+++ b/.changeset/petite-impalas-reply.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+chore: use `context.filename` and `context.physicalFilename` instead of compat functions.

--- a/packages/eslint-plugin-svelte/eslint.config.mjs
+++ b/packages/eslint-plugin-svelte/eslint.config.mjs
@@ -71,11 +71,11 @@ const config = [
 			'no-restricted-properties': [
 				'error',
 				{ object: 'context', property: 'getSourceCode', message: 'Use `context.sourceCode`' },
-				{ object: 'context', property: 'getFilename', message: 'Use src/utils/compat.ts' },
+				{ object: 'context', property: 'getFilename', message: 'Use `context.filename`' },
 				{
 					object: 'context',
 					property: 'getPhysicalFilename',
-					message: 'Use src/utils/compat.ts'
+					message: 'Use `context.physicalFilename`'
 				},
 				{ object: 'context', property: 'getCwd', message: 'Use src/utils/compat.ts' },
 				{ object: 'context', property: 'getScope', message: 'Use src/utils/compat.ts' },

--- a/packages/eslint-plugin-svelte/src/rules/comment-directive.ts
+++ b/packages/eslint-plugin-svelte/src/rules/comment-directive.ts
@@ -2,7 +2,6 @@ import type { AST } from 'svelte-eslint-parser';
 import { getShared } from '../shared/index.js';
 import type { CommentDirectives } from '../shared/comment-directives.js';
 import { createRule } from '../utils/index.js';
-import { getFilename } from '../utils/compat.js';
 
 type RuleAndLocation = {
 	ruleId: string;
@@ -54,7 +53,7 @@ export default createRule('comment-directive', {
 		type: 'problem'
 	},
 	create(context) {
-		const shared = getShared(getFilename(context));
+		const shared = getShared(context.filename);
 		if (!shared) return {};
 		const options = context.options[0] || {};
 		const reportUnusedDisableDirectives = Boolean(options.reportUnusedDisableDirectives);

--- a/packages/eslint-plugin-svelte/src/rules/indent-helpers/index.ts
+++ b/packages/eslint-plugin-svelte/src/rules/indent-helpers/index.ts
@@ -8,7 +8,6 @@ import { isCommentToken } from '@eslint-community/eslint-utils';
 import type { AnyToken, IndentOptions } from './commons.js';
 import type { OffsetCalculator } from './offset-context.js';
 import { OffsetContext } from './offset-context.js';
-import { getFilename } from '../../utils/compat.js';
 
 type IndentUserOptions = {
 	indent?: number | 'tab';
@@ -78,7 +77,7 @@ export function defineVisitor(
 	context: RuleContext,
 	defaultOptions: Partial<IndentOptions>
 ): RuleListener {
-	if (!getFilename(context).endsWith('.svelte')) return {};
+	if (!context.filename.endsWith('.svelte')) return {};
 
 	const options = parseOptions(context.options[0] || {}, defaultOptions);
 	const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
@@ -4,7 +4,6 @@ import type { TSESTree } from '@typescript-eslint/types';
 import type ts from 'typescript';
 import { findVariable } from '../utils/ast-utils.js';
 import { toRegExp } from '../utils/regexp.js';
-import { getFilename } from '../utils/compat.js';
 
 type PropertyPathArray = string[];
 
@@ -58,7 +57,7 @@ export default createRule('no-unused-props', {
 		]
 	},
 	create(context) {
-		const fileName = getFilename(context);
+		const fileName = context.filename;
 		const tools = getTypeScriptTools(context);
 		if (!tools) {
 			return {};

--- a/packages/eslint-plugin-svelte/src/rules/system.ts
+++ b/packages/eslint-plugin-svelte/src/rules/system.ts
@@ -1,6 +1,5 @@
 import { getShared } from '../shared/index.js';
 import { createRule } from '../utils/index.js';
-import { getFilename } from '../utils/compat.js';
 import { isRegExp, toRegExp } from '../utils/regexp.js';
 
 export default createRule('system', {
@@ -15,7 +14,7 @@ export default createRule('system', {
 		type: 'problem'
 	},
 	create(context) {
-		const shared = getShared(getFilename(context));
+		const shared = getShared(context.filename);
 		if (!shared) return {};
 
 		const directives = shared.newCommentDirectives({

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/less.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/less.ts
@@ -3,7 +3,6 @@ import type less from 'less';
 import type { RuleContext } from '../../../types.js';
 import type { TransformResult } from './types.js';
 import { loadModule } from '../../../utils/load-module.js';
-import { getFilename } from '../../../utils/compat.js';
 
 type Less = typeof less;
 /**
@@ -26,7 +25,7 @@ export function transform(
 	}
 	const code = text.slice(...inputRange);
 
-	const filename = `${getFilename(context)}.less`;
+	const filename = `${context.filename}.less`;
 	try {
 		let output: Awaited<ReturnType<Less['render']>> | undefined;
 

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/postcss.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/postcss.ts
@@ -3,7 +3,7 @@ import postcss from 'postcss';
 import postcssLoadConfig from 'postcss-load-config';
 import type { RuleContext } from '../../../types.js';
 import type { TransformResult } from './types.js';
-import { getCwd, getFilename } from '../../../utils/compat.js';
+import { getCwd } from '../../../utils/compat.js';
 
 /**
  * Transform with postcss
@@ -25,7 +25,7 @@ export function transform(
 	}
 	const code = text.slice(...inputRange);
 
-	const filename = `${getFilename(context)}.css`;
+	const filename = `${context.filename}.css`;
 	try {
 		const configFilePath = postcssConfig?.configFilePath;
 

--- a/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/stylus.ts
+++ b/packages/eslint-plugin-svelte/src/shared/svelte-compile-warns/transform/stylus.ts
@@ -4,7 +4,6 @@ import type { RawSourceMap } from 'source-map-js';
 import type { RuleContext } from '../../../types.js';
 import type { TransformResult } from './types.js';
 import { loadModule } from '../../../utils/load-module.js';
-import { getFilename } from '../../../utils/compat.js';
 
 type Stylus = typeof stylus;
 /**
@@ -27,7 +26,7 @@ export function transform(
 	}
 	const code = text.slice(...inputRange);
 
-	const filename = `${getFilename(context)}.stylus`;
+	const filename = `${context.filename}.stylus`;
 	try {
 		let output: string | undefined;
 

--- a/packages/eslint-plugin-svelte/src/types.ts
+++ b/packages/eslint-plugin-svelte/src/types.ts
@@ -149,7 +149,7 @@ export type RuleContext = {
 
 	getDeclaredVariables(node: TSESTree.Node): Variable[];
 
-	getFilename(): string;
+	filename: string;
 
 	getScope(): Scope;
 
@@ -161,8 +161,8 @@ export type RuleContext = {
 
 	// eslint@6 does not have this method.
 	getCwd?: () => string;
-	// eslint@<7.11.0 does not have this method.
-	getPhysicalFilename?: () => string;
+
+	physicalFilename: string;
 };
 
 export type NodeOrToken = {

--- a/packages/eslint-plugin-svelte/src/utils/compat.ts
+++ b/packages/eslint-plugin-svelte/src/utils/compat.ts
@@ -1,25 +1,5 @@
-import {
-	getFilename as getFilenameBase,
-	getPhysicalFilename as getPhysicalFilenameBase,
-	getCwd as getCwdBase
-} from 'eslint-compat-utils';
+import { getCwd as getCwdBase } from 'eslint-compat-utils';
 import type { RuleContext } from '../types.js';
-
-/**
- * Gets the value of `context.filename`, but for older ESLint it returns the result of `context.getFilename()`.
- */
-export function getFilename(context: RuleContext): string {
-	return getFilenameBase(context as never);
-}
-/**
- * Gets the value of `context.physicalFilename`,
- * but for older ESLint it returns the result of `context.getPhysicalFilename()`.
- * Versions older than v7.28.0 return a value guessed from the result of `context.getFilename()`,
- * but it may be incorrect.
- */
-export function getPhysicalFilename(context: RuleContext): string {
-	return getPhysicalFilenameBase(context as never);
-}
 
 /**
  * Gets the value of `context.cwd`, but for older ESLint it returns the result of `context.getCwd()`.

--- a/packages/eslint-plugin-svelte/src/utils/load-module.ts
+++ b/packages/eslint-plugin-svelte/src/utils/load-module.ts
@@ -2,7 +2,7 @@ import type { AST } from 'svelte-eslint-parser';
 import Module from 'module';
 import path from 'path';
 import type { RuleContext } from '../types.js';
-import { getCwd, getFilename, getPhysicalFilename } from './compat.js';
+import { getCwd } from './compat.js';
 const cache = new WeakMap<AST.SvelteProgram, Record<string, unknown>>();
 const cache4b = new Map<string, unknown>();
 /**
@@ -27,9 +27,9 @@ export function loadModule<R>(context: RuleContext, name: string): R | null {
 	}
 	for (const relativeTo of [
 		// load from lint file name
-		getFilename(context),
+		context.filename,
 		// load from lint file name (physical)
-		getPhysicalFilename(context),
+		context.physicalFilename,
 		// load from this plugin module
 		typeof __filename !== 'undefined' ? __filename : ''
 	]) {

--- a/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
+++ b/packages/eslint-plugin-svelte/src/utils/svelte-context.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import { getPackageJsons } from './get-package-json.js';
 import { getNodeModule } from './get-node-module.js';
-import { getFilename } from './compat.js';
 import { createCache } from './cache.js';
 import { VERSION as SVELTE_VERSION } from 'svelte/compiler';
 
@@ -122,7 +121,7 @@ const svelteKitContextCache = createCache<Pick<
 function getSvelteKitContext(
 	context: RuleContext
 ): Pick<SvelteContext, 'svelteKitFileType' | 'svelteKitVersion'> {
-	const filePath = getFilename(context);
+	const filePath = context.filename;
 
 	const cached = svelteKitContextCache.get(filePath);
 	if (cached) return cached;
@@ -151,7 +150,7 @@ function getSvelteKitContext(
 			context.settings?.svelte?.kit?.files?.routes ??
 			context.sourceCode.parserServices.svelteParseContext?.svelteConfig?.kit?.files?.routes
 		)?.replace(/^\//, '') ?? 'src/routes';
-	const projectRootDir = getProjectRootDir(getFilename(context)) ?? '';
+	const projectRootDir = getProjectRootDir(context.filename) ?? '';
 
 	if (!filePath.startsWith(path.join(projectRootDir, routes))) {
 		const result: Pick<SvelteContext, 'svelteKitFileType' | 'svelteKitVersion'> = {
@@ -288,7 +287,7 @@ const svelteContextCache = createCache<SvelteContext | null>();
 export function getSvelteContext(context: RuleContext): SvelteContext | null {
 	const { parserServices } = context.sourceCode;
 	const { svelteParseContext } = parserServices;
-	const filePath = getFilename(context);
+	const filePath = context.filename;
 
 	const cached = svelteContextCache.get(filePath);
 	if (cached) return cached;


### PR DESCRIPTION
Since we now require latest 8.x, all versions of ESLint we support have both `context.filename` and `context.physicalFilename`.

In the old types, `physicalFilename` could be undefined but now will actually default to `filename` (so the type has also changed).

If #1173 lands first, this will have conflicts i'll resolve before we can merge.