### PR TITLE
fix(no-unused-props): handle alias props name properly

### DIFF
--- a/.changeset/fifty-jeans-thank.md
+++ b/.changeset/fifty-jeans-thank.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix(no-unused-props): handle alias props name properly

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/alias-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/alias-errors.yaml
@@ -1,0 +1,4 @@
+- message: "'test' is an unused Props property."
+  line: 7
+  column: 8
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/alias-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/alias-input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	type Props = {
+		test: string;
+		'aria-label'?: string;
+	};
+
+	const { 'aria-label': foo }: Props = $props();
+</script>
+
+{foo}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/alias-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/alias-input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	type Props = {
+		test: string;
+		'aria-label'?: string;
+	};
+
+	const { test, 'aria-label': ariaLabel }: Props = $props();
+</script>
+
+<h1>{test}</h1>
+<div aria-label={ariaLabel}>svelte/no-unused-props does not always respect aliases</div>


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1172
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1182

This PR currently has a false negative in the following case (`test` is unused but not reported):
I’d like to resolve this issue, but wasn’t able to find a good solution in a short time, so I’ve temporarily given up. I’m looking for someone who can help address this issue.

```svelte
<script lang="ts">
	type Props = {
		test: string;
		'aria-label'?: string;
	};

	const { 'aria-label': test }: Props = $props();
</script>

{test}
```