### PR TITLE
docs: update valid-each-key, require-each-key, no-at-html-tags, prefer-class-directive further reading links

### DIFF
--- a/docs/rules/no-at-html-tags.md
+++ b/docs/rules/no-at-html-tags.md
@@ -40,7 +40,7 @@ If you are certain the content passed to `{@html}` is sanitized HTML you can dis
 
 ## :books: Further Reading
 
-- [Svelte - Tutorial > 1. Introduction / HTML tags](https://svelte.dev/tutorial/html-tags)
+- [Svelte - Tutorial > Basic Svelte / Introduction / HTML tags](https://svelte.dev/tutorial/svelte/html-tags)
 
 ## :rocket: Version
 

--- a/docs/rules/prefer-class-directive.md
+++ b/docs/rules/prefer-class-directive.md
@@ -62,7 +62,7 @@ You cannot enforce this style by using [prettier-plugin-svelte]. That is, this r
 
 ## :books: Further Reading
 
-- [Svelte - Tutorial > 13. Classes / The class directive](https://svelte.dev/tutorial/classes)
+- [Svelte - Tutorial > Basic Svelte / Classes and styles / The class atribute](https://svelte.dev/tutorial/svelte/classes)
 
 ## :rocket: Version
 

--- a/docs/rules/require-each-key.md
+++ b/docs/rules/require-each-key.md
@@ -44,7 +44,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Svelte - Tutorial > 4. Logic / Keyed each blocks](https://svelte.dev/tutorial/svelte/keyed-each-blocks)
+- [Svelte - Tutorial > Basic Svelte / Logic / Keyed each blocks](https://svelte.dev/tutorial/svelte/keyed-each-blocks)
 
 ## :rocket: Version
 

--- a/docs/rules/valid-each-key.md
+++ b/docs/rules/valid-each-key.md
@@ -53,7 +53,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Svelte - Tutorial > 4. Logic / Keyed each blocks](https://svelte.dev/tutorial/keyed-each-blocks)
+- [Svelte - Tutorial > Basic Svelte / Logic / Keyed each blocks](https://svelte.dev/tutorial/svelte/keyed-each-blocks)
 
 ## :rocket: Version
 


### PR DESCRIPTION
These currently lead to 404s. Updating links as well as described paths to match current tutorial