### PR TITLE
chore: move compat dependency to devDependencies

### DIFF
--- a/packages/eslint-plugin-svelte/package.json
+++ b/packages/eslint-plugin-svelte/package.json
@@ -84,7 +84,6 @@
     "acorn": "^8.14.0",
     "assert": "^2.1.0",
     "esbuild": "^0.25.0",
-    "eslint-compat-utils": "^0.6.4",
     "eslint-scope": "^8.2.0",
     "eslint-typegen": "^2.0.0",
     "eslint-visitor-keys": "^4.2.0",

--- a/packages/eslint-plugin-svelte/package.json
+++ b/packages/eslint-plugin-svelte/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.4.1",
     "@jridgewell/sourcemap-codec": "^1.5.0",
-    "eslint-compat-utils": "^0.6.4",
     "esutils": "^2.0.3",
     "known-css-properties": "^0.35.0",
     "postcss": "^8.4.49",
@@ -85,6 +84,7 @@
     "acorn": "^8.14.0",
     "assert": "^2.1.0",
     "esbuild": "^0.25.0",
+    "eslint-compat-utils": "^0.6.4",
     "eslint-scope": "^8.2.0",
     "eslint-typegen": "^2.0.0",
     "eslint-visitor-keys": "^4.2.0",

--- a/packages/eslint-plugin-svelte/tests/utils/eslint-compat.ts
+++ b/packages/eslint-plugin-svelte/tests/utils/eslint-compat.ts
@@ -1,3 +1,9 @@
-import { getRuleTester } from 'eslint-compat-utils/rule-tester';
+import * as eslint from 'eslint';
+import * as experimental from 'eslint/use-at-your-own-risk';
 
-export const RuleTester = getRuleTester();
+type MaybeHasRuleTester = {
+	FlatRuleTester?: typeof eslint.RuleTester;
+};
+
+export const RuleTester =
+	(experimental as never as MaybeHasRuleTester).FlatRuleTester ?? eslint.RuleTester;


### PR DESCRIPTION
We no longer use it in production code, only in tests. So we can move this to `devDependencies` now.