### PR TITLE
feat(no-unused-class-name): Support Regex for `allowedClassNames` option

### DIFF
--- a/.changeset/fast-bottles-allow.md
+++ b/.changeset/fast-bottles-allow.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+feat: support regex for allowedClassNames of no-unused-class-name rule

--- a/.changeset/fast-bottles-allow.md
+++ b/.changeset/fast-bottles-allow.md
@@ -1,5 +1,0 @@
----
-'eslint-plugin-svelte': patch
----
-
-feat: support regex for allowedClassNames of no-unused-class-name rule

--- a/.changeset/forty-signs-smoke.md
+++ b/.changeset/forty-signs-smoke.md
@@ -2,4 +2,4 @@
 'eslint-plugin-svelte': minor
 ---
 
-feat(no-unused-class-name): Support Regex for allowedClassNames option
+feat(no-unused-class-name): support regex for `allowedClassNames` option

--- a/.changeset/forty-signs-smoke.md
+++ b/.changeset/forty-signs-smoke.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': minor
+---
+
+feat(no-unused-class-name): Support Regex for allowedClassNames option

--- a/docs/rules/no-unused-class-name.md
+++ b/docs/rules/no-unused-class-name.md
@@ -53,7 +53,7 @@ This rule is aimed at reducing unused classes in the HTML template. While `svelt
   "svelte/no-unused-class-name": [
     "error",
     {
-      "allowedClassNames": ["class-name-one", "class-name-two"]
+      "allowedClassNames": ["class-name-one", "class-name-two", "/^regex-.*$/"] // You can also use regex to match class names
     }
   ]
 }

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -4,7 +4,7 @@ import type { AnyNode } from 'postcss';
 import type { Node as SelectorNode } from 'postcss-selector-parser';
 import { findClassesInAttribute } from '../utils/ast-utils.js';
 import type { SourceCode } from '../types.js';
-import { isRegExp, toRegExp } from 'src/utils/regexp.js';
+import { toRegExp } from 'src/utils/regexp.js';
 
 export default createRule('no-unused-class-name', {
 	meta: {

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -4,7 +4,7 @@ import type { AnyNode } from 'postcss';
 import type { Node as SelectorNode } from 'postcss-selector-parser';
 import { findClassesInAttribute } from '../utils/ast-utils.js';
 import type { SourceCode } from '../types.js';
-import { toRegExp } from 'src/utils/regexp.js';
+import { toRegExp } from '../utils/regexp.js';
 
 export default createRule('no-unused-class-name', {
 	meta: {

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -4,6 +4,7 @@ import type { AnyNode } from 'postcss';
 import type { Node as SelectorNode } from 'postcss-selector-parser';
 import { findClassesInAttribute } from '../utils/ast-utils.js';
 import type { SourceCode } from '../types.js';
+import { isRegExp, toRegExp } from 'src/utils/regexp.js';
 
 export default createRule('no-unused-class-name', {
 	meta: {
@@ -60,12 +61,11 @@ export default createRule('no-unused-class-name', {
 					if (
 						!allowedClassNames.includes(className) &&
 						!allowedClassNames.some((allowedClassName: string) => {
-							const regex = /^\/(.*)\/$/.exec(allowedClassName);
-							if (regex == null || regex[1] == null) {
+							if (!isRegExp(allowedClassName)) {
 								return false;
 							}
 
-							return new RegExp(regex[1]).test(className);
+							return toRegExp(allowedClassName).test(className);
 						}) &&
 						!classesUsedInStyle.includes(className)
 					) {

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -57,7 +57,18 @@ export default createRule('no-unused-class-name', {
 						? findClassesInPostCSSNode(styleContext.sourceAst, sourceCode.parserServices)
 						: [];
 				for (const className in classesUsedInTemplate) {
-					if (!allowedClassNames.includes(className) && !classesUsedInStyle.includes(className)) {
+					if (
+						!allowedClassNames.includes(className) &&
+						!allowedClassNames.some((allowedClassName: string) => {
+							const regex = /^\/(.*)\/$/.exec(allowedClassName);
+							if (regex == null || regex[1] == null) {
+								return false;
+							}
+
+							return new RegExp(regex[1]).test(className);
+						}) &&
+						!classesUsedInStyle.includes(className)
+					) {
 						context.report({
 							loc: classesUsedInTemplate[className],
 							message: `Unused class "${className}".`

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-class-name.ts
@@ -59,14 +59,9 @@ export default createRule('no-unused-class-name', {
 						: [];
 				for (const className in classesUsedInTemplate) {
 					if (
-						!allowedClassNames.includes(className) &&
-						!allowedClassNames.some((allowedClassName: string) => {
-							if (!isRegExp(allowedClassName)) {
-								return false;
-							}
-
-							return toRegExp(allowedClassName).test(className);
-						}) &&
+						!allowedClassNames.some((allowedClassName: string) =>
+							toRegExp(allowedClassName).test(className)
+						) &&
 						!classesUsedInStyle.includes(className)
 					) {
 						context.report({

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/invalid/allowed-class-names/_config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/invalid/allowed-class-names/_config.json
@@ -1,3 +1,3 @@
 {
-	"options": [{ "allowedClassNames": ["div-class"] }]
+	"options": [{ "allowedClassNames": ["div-class", "/^p-\\d{1,2}$/"] }]
 }

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/invalid/allowed-class-names/partially-allowed-class-name01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/invalid/allowed-class-names/partially-allowed-class-name01-errors.yaml
@@ -2,3 +2,7 @@
   line: 3
   column: 1
   suggestions: null
+- message: Unused class "p-100".
+  line: 5
+  column: 1
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/invalid/allowed-class-names/partially-allowed-class-name01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/invalid/allowed-class-names/partially-allowed-class-name01-input.svelte
@@ -1,3 +1,5 @@
 <div class="div-class">Hello</div>
 
 <span class="span-class">World!</span>
+
+<span class="p-100">Regex!</span>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/valid/allowed-class-names/_config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/valid/allowed-class-names/_config.json
@@ -1,3 +1,3 @@
 {
-	"options": [{ "allowedClassNames": ["div-class", "span-class"] }]
+	"options": [{ "allowedClassNames": ["div-class", "span-class", "/^p-\\d{1,2}$/"] }]
 }

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/valid/allowed-class-names/allowed-class-name01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-class-name/valid/allowed-class-names/allowed-class-name01-input.svelte
@@ -1,3 +1,5 @@
 <div class="div-class">Hello</div>
 
 <span class="span-class">World!</span>
+
+<span class="p-2">Regex!</span>


### PR DESCRIPTION
### Motivation

When I use this rule for project which is using `unocss`, I want to add unocss's [dynamic-rules](https://unocss.dev/config/rules#dynamic-rules) to `allowedClassNames`
ex) `/^m-(\d+)$/`
