### PR TITLE
chore: warn unnecessary-state-wrap

### DIFF
--- a/.changeset/gentle-buses-trade.md
+++ b/.changeset/gentle-buses-trade.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+chore: warn unnecessary-state-wrap

--- a/packages/eslint-plugin-svelte/src/configs/flat/recommended.ts
+++ b/packages/eslint-plugin-svelte/src/configs/flat/recommended.ts
@@ -32,7 +32,7 @@ const config: Linter.Config[] = [
 			'svelte/no-store-async': 'error',
 			'svelte/no-svelte-internal': 'error',
 			'svelte/no-unknown-style-directive-property': 'error',
-			'svelte/no-unnecessary-state-wrap': 'error',
+			'svelte/no-unnecessary-state-wrap': 'warn',
 			'svelte/no-unused-props': 'error',
 			'svelte/no-unused-svelte-ignore': 'error',
 			'svelte/no-useless-children-snippet': 'error',


### PR DESCRIPTION
There are cases where `SvelteSet` has to be reassigned. Reference https://github.com/sveltejs/svelte/issues/16422#issuecomment-3084031841

```svelte
<script lang="ts">
  import { SvelteSet } from 'svelte/reactivity';

  // SvelteSet is already reactive, $state wrapping is unnecessary.
  let ids = $state(new SvelteSet([1]));
  const count = $derived(ids.size); // added
</script>

{#each ids as id (id)}{id}{/each}

<button type="button" onclick={() => (ids = new SvelteSet([2]))}>
  Update IDs
</button>
```

Since it is considered a [best practice](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unnecessary-state-wrap/), I believe the recommendation can be lowered from error to warn.

This will allow devs to comment out the ESLint warning when needed with confidence.