### PR TITLE
feat(no-navigation-without-resolve): added to recommended rule set

### DIFF
--- a/.changeset/bitter-aliens-relax.md
+++ b/.changeset/bitter-aliens-relax.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': minor
+---
+
+feat(no-navigation-without-resolve): added to recommended rule set

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ These rules relate to SvelteKit and its best Practices.
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [svelte/no-export-load-in-svelte-module-in-kit-pages](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-export-load-in-svelte-module-in-kit-pages/) | disallow exporting load functions in `*.svelte` module in SvelteKit page components. | :star: |
-| [svelte/no-navigation-without-resolve](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-navigation-without-resolve/) | disallow using navigation (links, goto, pushState, replaceState) without a resolve() |  |
+| [svelte/no-navigation-without-resolve](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-navigation-without-resolve/) | disallow using navigation (links, goto, pushState, replaceState) without a resolve() | :star: |
 | [svelte/valid-prop-names-in-kit-pages](https://sveltejs.github.io/eslint-plugin-svelte/rules/valid-prop-names-in-kit-pages/) | disallow props other than data or errors in SvelteKit page components. | :star: |
 
 ## Experimental

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -120,7 +120,7 @@ These rules relate to SvelteKit and its best Practices.
 | Rule ID                                                                                                        | Description                                                                          |        |
 | :------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :----- |
 | [svelte/no-export-load-in-svelte-module-in-kit-pages](./rules/no-export-load-in-svelte-module-in-kit-pages.md) | disallow exporting load functions in `*.svelte` module in SvelteKit page components. | :star: |
-| [svelte/no-navigation-without-resolve](./rules/no-navigation-without-resolve.md)                               | disallow using navigation (links, goto, pushState, replaceState) without a resolve() |        |
+| [svelte/no-navigation-without-resolve](./rules/no-navigation-without-resolve.md)                               | disallow using navigation (links, goto, pushState, replaceState) without a resolve() | :star: |
 | [svelte/valid-prop-names-in-kit-pages](./rules/valid-prop-names-in-kit-pages.md)                               | disallow props other than data or errors in SvelteKit page components.               | :star: |
 
 ## Experimental

--- a/docs/rules/no-navigation-without-resolve.md
+++ b/docs/rules/no-navigation-without-resolve.md
@@ -10,6 +10,7 @@ description: 'disallow using navigation (links, goto, pushState, replaceState) w
 > disallow using navigation (links, goto, pushState, replaceState) without a resolve()
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+- :gear: This rule is included in `"plugin:svelte/recommended"`.
 
 ## :book: Rule Details
 

--- a/packages/eslint-plugin-svelte/src/configs/flat/recommended.ts
+++ b/packages/eslint-plugin-svelte/src/configs/flat/recommended.ts
@@ -22,6 +22,7 @@ const config: Linter.Config[] = [
 			'svelte/no-immutable-reactive-statements': 'error',
 			'svelte/no-inner-declarations': 'error',
 			'svelte/no-inspect': 'warn',
+			'svelte/no-navigation-without-resolve': 'error',
 			'svelte/no-not-function-handler': 'error',
 			'svelte/no-object-in-text-mustaches': 'error',
 			'svelte/no-raw-special-elements': 'error',

--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
@@ -11,7 +11,7 @@ export default createRule('no-navigation-without-resolve', {
 			description:
 				'disallow using navigation (links, goto, pushState, replaceState) without a resolve()',
 			category: 'SvelteKit',
-			recommended: false
+			recommended: true
 		},
 		schema: [
 			{


### PR DESCRIPTION
Since the rule is now restricted to running only on SvelteKit files, I think it's safe to add it to the recommended rule set.
