### PR TITLE
fix: Not reporting mailto: and other unusual schema addresses in no-nmavigation-without-resolve (and its deprecated versions)

### DIFF
--- a/.changeset/six-pugs-camp.md
+++ b/.changeset/six-pugs-camp.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: Not reporting mailto: and other unusual schema addresses in no-nmavigation-without-resolve (and its deprecated versions)

--- a/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-goto-without-base.ts
@@ -71,8 +71,7 @@ function checkTemplateLiteral(
 }
 
 function checkLiteral(context: RuleContext, path: TSESTree.Literal): void {
-	const absolutePathRegex = /^(?:[+a-z]+:)?\/\//i;
-	if (!absolutePathRegex.test(path.value?.toString() ?? '')) {
+	if (!/^[+a-z]*:/i.test(path.value?.toString() ?? '')) {
 		context.report({ loc: path.loc, messageId: 'isNotPrefixedWithBasePath' });
 	}
 }

--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-base.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-base.ts
@@ -268,7 +268,7 @@ function templateLiteralIsAbsolute(url: TSESTree.TemplateLiteral): boolean {
 }
 
 function urlValueIsAbsolute(url: string): boolean {
-	return url.includes('://');
+	return /^[+a-z]*:/i.test(url);
 }
 
 function expressionIsFragment(url: AST.SvelteLiteral | TSESTree.Expression): boolean {

--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
@@ -282,7 +282,7 @@ function templateLiteralIsAbsolute(url: TSESTree.TemplateLiteral): boolean {
 }
 
 function urlValueIsAbsolute(url: string): boolean {
-	return url.includes('://');
+	return /^[+a-z]*:/i.test(url);
 }
 
 function expressionIsFragment(url: AST.SvelteLiteral | TSESTree.Expression): boolean {

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-goto-without-base/invalid/no-base01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-goto-without-base/invalid/no-base01-errors.yaml
@@ -2,3 +2,7 @@
   line: 4
   column: 7
   suggestions: null
+- message: Found a goto() call with a url that isn't prefixed with the base path.
+  line: 5
+  column: 7
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-goto-without-base/invalid/no-base01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-goto-without-base/invalid/no-base01-input.svelte
@@ -2,4 +2,5 @@
 	import { goto } from '$app/navigation';
 
 	goto('/foo');
+	goto('/user:42');
 </script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-goto-without-base/valid/absolute-uri01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-goto-without-base/valid/absolute-uri01-input.svelte
@@ -3,4 +3,6 @@
 
 	goto('http://localhost/foo/');
 	goto('https://localhost/foo/');
+	goto('mailto:user@example.com');
+	goto('tel:+123456789');
 </script>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-no-base01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-no-base01-errors.yaml
@@ -14,3 +14,7 @@
   line: 7
   column: 9
   suggestions: null
+- message: Found a link with a url that isn't prefixed with the base path.
+  line: 8
+  column: 9
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-no-base01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-no-base01-input.svelte
@@ -5,3 +5,4 @@
 <a href={'/foo'}>Click me!</a>
 <a href={'/' + 'foo'}>Click me!</a>
 <a href={value}>Click me!</a>
+<a href={'/user:42'}>Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-with-fragment01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-with-fragment01-errors.yaml
@@ -14,3 +14,7 @@
   line: 7
   column: 9
   suggestions: null
+- message: Found a link with a url that isn't prefixed with the base path.
+  line: 8
+  column: 9
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-with-fragment01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/invalid/link-with-fragment01-input.svelte
@@ -5,3 +5,4 @@
 <a href={'/foo#section'}>Click me!</a>
 <a href={'/' + 'foo#section'}>Click me!</a>
 <a href={value}>Click me!</a>
+<a href={'/foo#section:42'}>Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/valid/link-absolute-url01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/valid/link-absolute-url01-input.svelte
@@ -11,3 +11,5 @@
 <a href={'http' + '://svelte.dev'}>Click me!</a>
 <a href={'https' + '://svelte.dev'}>Click me!</a>
 <a href={`${protocol}://svelte.dev`}>Click me!</a>
+<a href="mailto:user@example.com">Click me!</a>
+<a href="tel:+123456789">Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/valid/link-fragment-url01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-base/valid/link-fragment-url01-input.svelte
@@ -8,3 +8,4 @@
 <a href={'#' + 'section'}>Click me!</a>
 <a href={'#' + section}>Click me!</a>
 <a href={`#${section}`}>Click me!</a>
+<a href={'#user:42'}>Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-with-fragment01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-with-fragment01-errors.yaml
@@ -14,3 +14,7 @@
   line: 8
   column: 9
   suggestions: null
+- message: Found a link with a url that isn't resolved.
+  line: 9
+  column: 9
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-with-fragment01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-with-fragment01-input.svelte
@@ -6,3 +6,4 @@
 <a href={'/foo#section'}>Click me!</a>
 <a href={'/' + 'foo#section'}>Click me!</a>
 <a href={value}>Click me!</a>
+<a href={'/foo#section:42'}>Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-without-resolve01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-without-resolve01-errors.yaml
@@ -14,3 +14,7 @@
   line: 8
   column: 9
   suggestions: null
+- message: Found a link with a url that isn't resolved.
+  line: 9
+  column: 9
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-without-resolve01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-without-resolve01-input.svelte
@@ -6,3 +6,4 @@
 <a href={'/foo'}>Click me!</a>
 <a href={'/' + 'foo'}>Click me!</a>
 <a href={value}>Click me!</a>
+<a href={'/user:42'}>Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-absolute-url01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-absolute-url01-input.svelte
@@ -11,3 +11,5 @@
 <a href={'http' + '://svelte.dev'}>Click me!</a>
 <a href={'https' + '://svelte.dev'}>Click me!</a>
 <a href={`${protocol}://svelte.dev`}>Click me!</a>
+<a href="mailto:user@example.com">Click me!</a>
+<a href="tel:+123456789">Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-fragment-url01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-fragment-url01-input.svelte
@@ -8,3 +8,4 @@
 <a href={'#' + 'section'}>Click me!</a>
 <a href={'#' + section}>Click me!</a>
 <a href={`#${section}`}>Click me!</a>
+<a href={'#user:42'}>Click me!</a>


### PR DESCRIPTION
Fixes #1311
