### PR TITLE
chore: align `repository` field with svelte repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "funding": "https://github.com/sponsors/ota-meshi",
   "packageManager": "pnpm@10.15.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sveltejs/eslint-plugin-svelte.git"
+  },
   "scripts": {
     "prerelease": "cd packages/eslint-plugin-svelte && pnpm clean && pnpm run build && cd ../.. && cp README.md packages/eslint-plugin-svelte",
     "release": "changeset publish",

--- a/packages/eslint-plugin-svelte/package.json
+++ b/packages/eslint-plugin-svelte/package.json
@@ -2,7 +2,11 @@
   "name": "eslint-plugin-svelte",
   "version": "3.12.3",
   "description": "ESLint plugin for Svelte using AST",
-  "repository": "git+https://github.com/sveltejs/eslint-plugin-svelte.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sveltejs/eslint-plugin-svelte.git",
+    "directory": "packages/eslint-plugin-svelte"
+  },
   "homepage": "https://sveltejs.github.io/eslint-plugin-svelte",
   "author": "Yosuke Ota (https://github.com/ota-meshi)",
   "funding": "https://github.com/sponsors/ota-meshi",


### PR DESCRIPTION
I'm trying to fix release action.
https://github.com/sveltejs/eslint-plugin-svelte/actions/runs/17599926478/job/49999938393

I still haven’t figured out the cause of the failures, but I’m going through the configuration differences with the Svelte repository one by one.