### PR TITLE
chore: try to update npm for release action

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install Dependencies
         run: pnpm install
 


### PR DESCRIPTION
I don't think we need this but I can not find any other reason why the release is failed...