### PR TITLE
feat: add windows support

### DIFF
--- a/.changeset/icy-rocks-camp.md
+++ b/.changeset/icy-rocks-camp.md
@@ -1,0 +1,8 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: properly support Windows in `no-unused-props` rule
+fix: properly support Windows in `valid-style-parse` rule
+fix: properly support Windows in `nno-unnecessary-condition` rule
+fix: properly support Windows in update tools

--- a/.changeset/icy-rocks-camp.md
+++ b/.changeset/icy-rocks-camp.md
@@ -4,4 +4,4 @@
 
 fix: properly support Windows in `no-unused-props` rule
 fix: properly support Windows in `valid-style-parse` rule
-fix: properly support Windows in `nno-unnecessary-condition` rule
+fix: properly support Windows in `no-unnecessary-condition` rule

--- a/.changeset/icy-rocks-camp.md
+++ b/.changeset/icy-rocks-camp.md
@@ -5,4 +5,3 @@
 fix: properly support Windows in `no-unused-props` rule
 fix: properly support Windows in `valid-style-parse` rule
 fix: properly support Windows in `nno-unnecessary-condition` rule
-fix: properly support Windows in update tools

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -11,6 +11,8 @@ env:
 
 defaults:
   run:
+    # Setting every runner to bash simplifies command calls;
+    #  plus, every platform supports it
     shell: bash
 
 jobs:

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -9,6 +9,10 @@ on:
 env:
   project_root_path: ./packages/eslint-plugin-svelte
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -51,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,windows-latest]
+        os: [ubuntu-latest, windows-latest]
         eslint: [8, 9]
         node: [18.x, 20.x, 22.x, latest]
     steps:

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest,windows-latest]
         eslint: [8, 9]
         node: [18.x, 20.x, 22.x, latest]
     steps:

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         eslint: [8, 9]
         node: [18.x, 20.x, 22.x, latest]
     steps:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         eslint: [9]
         node: [18, 20, 22]
     steps:
@@ -115,7 +115,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         node: [18]
     steps:
       - name: Checkout

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"[typescript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	}
+	},
+	"files.eol": "\n"
 }

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
@@ -4,6 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import type ts from 'typescript';
 import { findVariable } from '../utils/ast-utils.js';
 import { toRegExp } from '../utils/regexp.js';
+import { normalize } from 'path';
 
 type PropertyPathArray = string[];
 type DeclaredPropertyNames = Set<{ originalName: string; aliasName: string }>;
@@ -122,7 +123,7 @@ export default createRule('no-unused-props', {
 			const declarations = symbol.getDeclarations();
 			if (!declarations || declarations.length === 0) return false;
 
-			return declarations.every((decl) => decl.getSourceFile().fileName === fileName);
+			return declarations.every((decl) => normalize(decl.getSourceFile().fileName) === fileName);
 		}
 
 		/**

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
@@ -123,6 +123,7 @@ export default createRule('no-unused-props', {
 			const declarations = symbol.getDeclarations();
 			if (!declarations || declarations.length === 0) return false;
 
+			// TypeScript declaration file name is normalized to support Windows style paths
 			return declarations.every((decl) => normalize(decl.getSourceFile().fileName) === fileName);
 		}
 

--- a/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
+++ b/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
@@ -23,6 +23,8 @@ export default createRule('valid-style-parse', {
 			SvelteStyleElement(node) {
 				const styleContext = sourceCode.parserServices.getStyleContext!();
 				if (styleContext.status === 'parse-error') {
+					// This will replace backslashes to forward slashes only
+					// 	if Node.js reports Windows style path separators
 					let message = styleContext.error.message.replace(cwd, '');
 					if (path.sep === '\\') message = message.replace(/\\/g, '/');
 

--- a/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
+++ b/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
@@ -23,9 +23,12 @@ export default createRule('valid-style-parse', {
 			SvelteStyleElement(node) {
 				const styleContext = sourceCode.parserServices.getStyleContext!();
 				if (styleContext.status === 'parse-error') {
+					let message = styleContext.error.message.replace(cwd, '');
+					if (path.sep === '\\') message = message.replace(/\\/g, '/');
+
 					context.report({
 						loc: node.loc,
-						message: `Error parsing style element. Error message: "${path.posix.normalize(styleContext.error.message.replace(cwd, ''))}"`
+						message: `Error parsing style element. Error message: "${message}"`
 					});
 				}
 				if (styleContext.status === 'unknown-lang') {

--- a/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
+++ b/packages/eslint-plugin-svelte/src/rules/valid-style-parse.ts
@@ -1,4 +1,5 @@
 import { createRule } from '../utils/index.js';
+import path from 'path';
 
 export default createRule('valid-style-parse', {
 	meta: {
@@ -16,7 +17,7 @@ export default createRule('valid-style-parse', {
 		if (!sourceCode.parserServices.isSvelte) {
 			return {};
 		}
-		const cwd = `${context.cwd ?? process.cwd()}/`;
+		const cwd = `${context.cwd ?? process.cwd()}${path.sep}`;
 
 		return {
 			SvelteStyleElement(node) {
@@ -24,7 +25,7 @@ export default createRule('valid-style-parse', {
 				if (styleContext.status === 'parse-error') {
 					context.report({
 						loc: node.loc,
-						message: `Error parsing style element. Error message: "${styleContext.error.message.replace(cwd, '')}"`
+						message: `Error parsing style element. Error message: "${path.posix.normalize(styleContext.error.message.replace(cwd, ''))}"`
 					});
 				}
 				if (styleContext.status === 'unknown-lang') {

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-css01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-css01-errors.yaml
@@ -1,5 +1,5 @@
 - message: 'Error parsing style element. Error message:
-    "tests/fixtures/rules/valid-style-parse/invalid/invalid-css01-input.svelte:4:11:
+    "tests\fixtures\rules\valid-style-parse\invalid\invalid-css01-input.svelte:4:11:
     Unknown word .div-class/35"'
   line: 7
   column: 1

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-css01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-css01-errors.yaml
@@ -1,5 +1,5 @@
 - message: 'Error parsing style element. Error message:
-    "tests\fixtures\rules\valid-style-parse\invalid\invalid-css01-input.svelte:4:11:
+    "tests/fixtures/rules/valid-style-parse/invalid/invalid-css01-input.svelte:4:11:
     Unknown word .div-class/35"'
   line: 7
   column: 1

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-scss01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-scss01-errors.yaml
@@ -1,5 +1,5 @@
 - message: 'Error parsing style element. Error message:
-    "tests/fixtures/rules/valid-style-parse/invalid/invalid-scss01-input.svelte:4:11:
+    "tests\fixtures\rules\valid-style-parse\invalid\invalid-scss01-input.svelte:4:11:
     Unknown word .div-class/35"'
   line: 7
   column: 1

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-scss01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/valid-style-parse/invalid/invalid-scss01-errors.yaml
@@ -1,5 +1,5 @@
 - message: 'Error parsing style element. Error message:
-    "tests\fixtures\rules\valid-style-parse\invalid\invalid-scss01-input.svelte:4:11:
+    "tests/fixtures/rules/valid-style-parse/invalid/invalid-scss01-input.svelte:4:11:
     Unknown word .div-class/35"'
   line: 7
   column: 1

--- a/packages/eslint-plugin-svelte/tests/src/rules/@typescript-eslint/original-tests/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin-svelte/tests/src/rules/@typescript-eslint/original-tests/no-unnecessary-condition.ts
@@ -2,13 +2,15 @@
 // https://github.com/typescript-eslint/typescript-eslint/blob/78467fc1bde9bd2db1e08b3d19f151f4adaff8a9/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
 /* eslint func-style: off, eslint-plugin/consistent-output: off -- respect original  */
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { RuleTester } from '../../../../utils/eslint-compat.js';
 import type * as eslint from 'eslint';
 import * as typescriptParser from '@typescript-eslint/parser';
 
 import rule from '../../../../../src/rules/@typescript-eslint/no-unnecessary-condition.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const url = new URL(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(url));
 
 function getFixturesRootDir(): string {
 	return path.join(__dirname, 'fixtures');

--- a/packages/eslint-plugin-svelte/tests/utils/utils.ts
+++ b/packages/eslint-plugin-svelte/tests/utils/utils.ts
@@ -305,7 +305,7 @@ function writeFixtures(
 }
 
 function getConfig(ruleName: string, inputFile: string) {
-	const filename = inputFile.slice(inputFile.indexOf(ruleName));
+	const filename = inputFile.slice(inputFile.indexOf(path.normalize(ruleName)));
 	const code = fs.readFileSync(inputFile, 'utf8');
 	let config;
 	let configFile = [

--- a/packages/eslint-plugin-svelte/tests/utils/utils.ts
+++ b/packages/eslint-plugin-svelte/tests/utils/utils.ts
@@ -12,8 +12,9 @@ import * as svelteParser from 'svelte-eslint-parser';
 import * as typescriptParser from '@typescript-eslint/parser';
 import Module from 'module';
 import globals from 'globals';
+import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(new URL(import.meta.url)));
 const require = Module.createRequire(import.meta.url);
 
 /**

--- a/packages/eslint-plugin-svelte/tests/utils/utils.ts
+++ b/packages/eslint-plugin-svelte/tests/utils/utils.ts
@@ -305,6 +305,7 @@ function writeFixtures(
 }
 
 function getConfig(ruleName: string, inputFile: string) {
+	// ruleName is normalized to support Windows style paths
 	const filename = inputFile.slice(inputFile.indexOf(path.normalize(ruleName)));
 	const code = fs.readFileSync(inputFile, 'utf8');
 	let config;

--- a/packages/eslint-plugin-svelte/tools/lib/changesets-util.ts
+++ b/packages/eslint-plugin-svelte/tools/lib/changesets-util.ts
@@ -1,11 +1,11 @@
 import getReleasePlan from '@changesets/get-release-plan';
-import path from 'path';
+import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const cwdURL = new URL('../../../..', import.meta.url);
 
 /** Get new version string from changesets */
 export async function getNewVersion(): Promise<string> {
-	const releasePlan = await getReleasePlan(path.resolve(__dirname, '../../../..'));
+	const releasePlan = await getReleasePlan(fileURLToPath(cwdURL));
 
 	return releasePlan.releases.find(({ name }) => name === 'eslint-plugin-svelte')!.newVersion;
 }

--- a/packages/eslint-plugin-svelte/tools/lib/load-rules.ts
+++ b/packages/eslint-plugin-svelte/tools/lib/load-rules.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 import type { RuleModule } from '../../src/types.js';
-import util from 'util';
 
 const rulesLibRootURL = new URL('../../src/rules/', import.meta.url);
 

--- a/packages/eslint-plugin-svelte/tools/lib/load-rules.ts
+++ b/packages/eslint-plugin-svelte/tools/lib/load-rules.ts
@@ -1,18 +1,18 @@
 import path from 'path';
 import fs from 'fs';
 import type { RuleModule } from '../../src/types.js';
+import util from 'util';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const rulesLibRootURL = new URL('../../src/rules/', import.meta.url);
 
 /**
  * Get the all rules
  * @returns {Array} The all rules
  */
 async function readRules() {
-	const rulesLibRoot = path.resolve(__dirname, '../../src/rules');
 	const rules: RuleModule[] = [];
 	for (const name of iterateTsFiles()) {
-		const module = await import(path.join(rulesLibRoot, name));
+		const module = await import(new URL(name, rulesLibRootURL).href);
 		const rule: RuleModule = module && module.default;
 		if (!rule || typeof rule.create !== 'function') {
 			continue;
@@ -27,8 +27,7 @@ export const rules = await readRules();
 
 /** Iterate ts files */
 function* iterateTsFiles() {
-	const rulesLibRoot = path.resolve(__dirname, '../../src/rules');
-	const files = fs.readdirSync(rulesLibRoot);
+	const files = fs.readdirSync(rulesLibRootURL);
 
 	while (files.length) {
 		const file = files.shift()!;
@@ -36,10 +35,10 @@ function* iterateTsFiles() {
 			yield file;
 			continue;
 		}
-		const filePath = path.join(rulesLibRoot, file);
-		if (!fs.statSync(filePath).isDirectory()) {
+		const filePathURL = new URL(file, rulesLibRootURL);
+		if (!fs.statSync(filePathURL).isDirectory()) {
 			continue;
 		}
-		files.unshift(...fs.readdirSync(filePath).map((n) => path.join(file, n)));
+		files.unshift(...fs.readdirSync(filePathURL).map((n) => path.join(file, n)));
 	}
 }

--- a/packages/eslint-plugin-svelte/tools/update-docs-rules-index.ts
+++ b/packages/eslint-plugin-svelte/tools/update-docs-rules-index.ts
@@ -1,13 +1,10 @@
-import path from 'path';
 import renderRulesTableContent from './render-rules.js';
 import { writeAndFormat } from './lib/write.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
-
 // -----------------------------------------------------------------------------
-const readmeFilePath = path.resolve(__dirname, '../../../docs/rules.md');
+const readmeFileURL = new URL('../../../docs/rules.md', import.meta.url);
 void writeAndFormat(
-	readmeFilePath,
+	readmeFileURL,
 	`---
 sidebarDepth: 0
 ---

--- a/packages/eslint-plugin-svelte/tools/update-docs.ts
+++ b/packages/eslint-plugin-svelte/tools/update-docs.ts
@@ -1,11 +1,8 @@
-import path from 'path';
 import fs from 'fs';
 import { rules } from '../src/utils/rules.js';
 import type { RuleModule } from '../src/types.js';
 import { getNewVersion } from './lib/changesets-util.js';
 import { writeAndFormat } from './lib/write.js';
-
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 function formatItems(items: string[]) {
 	if (items.length <= 2) {
@@ -21,7 +18,7 @@ function yamlValue(val: unknown) {
 	return val;
 }
 
-const ROOT = path.resolve(__dirname, '../../../docs/rules');
+const ROOT_URL = new URL('../../../docs/rules/', import.meta.url);
 
 function pickSince(content: string): string | null | Promise<string> {
 	const fileIntro = /^---\n((?:.*\n)+)---\n*/.exec(content);
@@ -46,7 +43,7 @@ function pickSince(content: string): string | null | Promise<string> {
 class DocFile {
 	private readonly rule: RuleModule;
 
-	private readonly filePath: string;
+	private readonly fileURL: URL;
 
 	private content: string;
 
@@ -54,8 +51,8 @@ class DocFile {
 
 	public constructor(rule: RuleModule) {
 		this.rule = rule;
-		this.filePath = path.join(ROOT, `${rule.meta.docs.ruleName}.md`);
-		this.content = fs.readFileSync(this.filePath, 'utf8');
+		this.fileURL = new URL(`./${rule.meta.docs.ruleName}.md`, ROOT_URL);
+		this.content = fs.readFileSync(this.fileURL, 'utf8');
 		this.since = pickSince(this.content);
 	}
 
@@ -221,7 +218,7 @@ ${
 	public async write() {
 		this.content = this.content.replace(/\r?\n/gu, '\n');
 
-		await writeAndFormat(this.filePath, this.content);
+		await writeAndFormat(this.fileURL, this.content);
 	}
 }
 

--- a/packages/eslint-plugin-svelte/tools/update-meta.ts
+++ b/packages/eslint-plugin-svelte/tools/update-meta.ts
@@ -1,10 +1,10 @@
-import path from 'path';
+import { fileURLToPath } from 'url';
 import { name, version } from '../package.json';
 import { getNewVersion } from './lib/changesets-util.js';
 import { writeAndFormat } from './lib/write.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
-const META_PATH = path.join(__dirname, '../src/meta.ts');
+const fileURL = new URL('../src/meta.ts', import.meta.url);
+const META_PATH = fileURLToPath(fileURL);
 
 void main();
 

--- a/packages/eslint-plugin-svelte/tools/update-meta.ts
+++ b/packages/eslint-plugin-svelte/tools/update-meta.ts
@@ -1,17 +1,15 @@
-import { fileURLToPath } from 'url';
 import { name, version } from '../package.json';
 import { getNewVersion } from './lib/changesets-util.js';
 import { writeAndFormat } from './lib/write.js';
 
-const fileURL = new URL('../src/meta.ts', import.meta.url);
-const META_PATH = fileURLToPath(fileURL);
+const META_URL = new URL('../src/meta.ts', import.meta.url);
 
 void main();
 
 /** main */
 async function main() {
 	await writeAndFormat(
-		META_PATH,
+		META_URL,
 		`/*
  * IMPORTANT!
  * This file has been automatically generated,

--- a/packages/eslint-plugin-svelte/tools/update-readme.ts
+++ b/packages/eslint-plugin-svelte/tools/update-readme.ts
@@ -1,27 +1,26 @@
-import path from 'path';
 import fs from 'fs';
 import renderRulesTableContent from './render-rules.js';
 import { writeAndFormat } from './lib/write.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const rootURL = new URL('../../../', import.meta.url);
 
 const insertText = `\n${renderRulesTableContent(
 	(name) => `https://sveltejs.github.io/eslint-plugin-svelte/rules/${name}/`
 )}\n`;
 
-const readmeFilePath = path.resolve(__dirname, '../../../README.md');
+const readmeFileURL = new URL('README.md', rootURL);
 const newReadme = fs
-	.readFileSync(readmeFilePath, 'utf8')
+	.readFileSync(readmeFileURL, 'utf8')
 	.replace(
 		/<!--RULES_TABLE_START-->[\s\S]*<!--RULES_TABLE_END-->/u,
 		`<!--RULES_TABLE_START-->${insertText.replace(/\$/g, '$$$$')}<!--RULES_TABLE_END-->`
 	);
-void writeAndFormat(readmeFilePath, newReadme);
+void writeAndFormat(readmeFileURL, newReadme);
 
-const docsReadmeFilePath = path.resolve(__dirname, '../../../docs/README.md');
+const docsReadmeFileURL = new URL('./docs/README.md', rootURL);
 
 void writeAndFormat(
-	docsReadmeFilePath,
+	docsReadmeFileURL,
 	`---
 title: "eslint-plugin-svelte"
 ---
@@ -65,12 +64,12 @@ ${newReadme
 	.replace(/\n{3,}/gu, '\n\n')}`
 );
 
-const docsUserGuideFilePath = path.resolve(__dirname, '../../../docs/user-guide.md');
+const docsUserGuideFileURL = new URL('./docs/user-guide.md', rootURL);
 
-const docsUserGuide = fs.readFileSync(docsUserGuideFilePath, 'utf8');
+const docsUserGuide = fs.readFileSync(docsUserGuideFileURL, 'utf8');
 
 void writeAndFormat(
-	docsUserGuideFilePath,
+	docsUserGuideFileURL,
 	docsUserGuide
 		.replace(
 			/<!--USAGE_GUIDE_START-->[\s\S]*<!--USAGE_GUIDE_END-->/u,

--- a/packages/eslint-plugin-svelte/tools/update-rule-types.ts
+++ b/packages/eslint-plugin-svelte/tools/update-rule-types.ts
@@ -1,8 +1,5 @@
 import fs from 'fs';
-import path from 'path';
 import plugin from '../src/index.js';
-
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 void main();
 
@@ -13,7 +10,7 @@ async function main() {
 	const ruleTypes = await pluginsToRulesDTS({ svelte: plugin });
 
 	void fs.writeFileSync(
-		path.join(__dirname, '../src/rule-types.ts'),
+		new URL('../src/rule-types.ts', import.meta.url),
 		`// IMPORTANT!
 // This file has been automatically generated,
 // in order to update its content execute "pnpm run update"

--- a/packages/eslint-plugin-svelte/tools/update-rules.ts
+++ b/packages/eslint-plugin-svelte/tools/update-rules.ts
@@ -1,9 +1,6 @@
-import path from 'path';
 // import eslint from "eslint"
 import { rules } from './lib/load-rules.js';
 import { writeAndFormat } from './lib/write.js';
-
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 /**
  * Convert text to camelCase
@@ -41,7 +38,7 @@ export const rules = [
 ] as RuleModule[]
 `;
 
-const filePath = path.resolve(__dirname, '../src/utils/rules.ts');
+const fileURL = new URL('../src/utils/rules.ts', import.meta.url);
 
 // Update file.
-void writeAndFormat(filePath, content);
+void writeAndFormat(fileURL, content);

--- a/packages/eslint-plugin-svelte/tools/update-rulesets.ts
+++ b/packages/eslint-plugin-svelte/tools/update-rulesets.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import { rules } from './lib/load-rules.js';
 import { writeAndFormat } from './lib/write.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const flatConfigFolderURL = new URL('../src/configs/flat/', import.meta.url);
 
 // ------------------
 // Flat Config
@@ -79,10 +78,10 @@ const config: Linter.Config[] = [
 export default config
 `;
 
-const baseFilePath = path.resolve(__dirname, '../src/configs/flat/base.ts');
+const baseFileURL = new URL('base.ts', flatConfigFolderURL);
 
 // Update file.
-void writeAndFormat(baseFilePath, baseContent);
+void writeAndFormat(baseFileURL, baseContent);
 
 const recommendedContent = `/*
  * IMPORTANT!
@@ -110,10 +109,10 @@ const config: Linter.Config[] = [
 export default config
 `;
 
-const recommendedFilePath = path.resolve(__dirname, '../src/configs/flat/recommended.ts');
+const recommendedFileURL = new URL('recommended.ts', flatConfigFolderURL);
 
 // Update file.
-void writeAndFormat(recommendedFilePath, recommendedContent);
+void writeAndFormat(recommendedFileURL, recommendedContent);
 
 const prettierContent = `/*
  * IMPORTANT!
@@ -138,7 +137,7 @@ const config: Linter.Config[] = [
 export default config
 `;
 
-const prettierFilePath = path.resolve(__dirname, '../src/configs/flat/prettier.ts');
+const prettierFileURL = new URL('prettier.ts', flatConfigFolderURL);
 
 // Update file.
-void writeAndFormat(prettierFilePath, prettierContent);
+void writeAndFormat(prettierFileURL, prettierContent);

--- a/packages/eslint-plugin-svelte/tools/update-types-for-node.ts
+++ b/packages/eslint-plugin-svelte/tools/update-types-for-node.ts
@@ -1,15 +1,11 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/types';
 import { parseForESLint } from 'svelte-eslint-parser';
-import path from 'path';
 import { writeAndFormat } from './lib/write.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const sourceFolderURL = new URL('../src/', import.meta.url);
 
-// import { fileURLToPath } from "url"
-// const filename = fileURLToPath(import.meta.url)
-const dirname = __dirname; // path.dirname(filename)
-const typesForNodeFilename = path.join(dirname, '../src/types-for-node.ts');
-const estreeFilename = path.join(dirname, '../src/type-defs/estree.d.ts');
+const typesForNodeFileURL = new URL('types-for-node.ts', sourceFolderURL);
+const estreeFileURL = new URL('type-defs/estree.d.ts', sourceFolderURL);
 const { visitorKeys } = parseForESLint('');
 
 const esNextNodeNames = ['Decorator', 'ImportAttribute', 'StaticBlock'];
@@ -119,5 +115,5 @@ for (const nodeType of svelteNodeNames.filter((k) => !esSvelteNodeNames.includes
 typesForNodeCode.push(`}`);
 
 estreeCode.push(`}`);
-void writeAndFormat(typesForNodeFilename, typesForNodeCode.join('\n'));
-void writeAndFormat(estreeFilename, estreeCode.join('\n'));
+void writeAndFormat(typesForNodeFileURL, typesForNodeCode.join('\n'));
+void writeAndFormat(estreeFileURL, estreeCode.join('\n'));

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+	endOfLine: 'lf',
 	useTabs: true,
 	singleQuote: true,
 	trailingComma: 'none',


### PR DESCRIPTION
This PR adds support for Windows environments.

It:
- Forces `\n` as the end-of-line character
- Normalizes paths whenever possible to stay cross-platform
- Enables Windows runners in NodeCI

closes #1335 