### PR TITLE
Explain the no-navigation-without-resolve rationale

### DIFF
--- a/docs/rules/no-navigation-without-resolve.md
+++ b/docs/rules/no-navigation-without-resolve.md
@@ -14,7 +14,7 @@ since: 'v3.12.0'
 
 ## :book: Rule Details
 
-This rule reports navigation using HTML `<a>` tags, SvelteKit's `goto()`, `pushState()` and `replaceState()` functions without resolving a relative URL. All four of these may be used for navigation, with `goto()`, `pushState()` and `replaceState()` being intended solely for internal navigation (i.e. not leaving the site), while `<a>` tags may be used for both internal and external navigation. When using any way of internal navigation, the URL must be resolved using SvelteKit's `resolve()`, otherwise the site may break. For programmatic navigation to external URLs, using `window.location` is advised.
+This rule reports navigation using HTML `<a>` tags, SvelteKit's `goto()`, `pushState()` and `replaceState()` functions without resolving a relative URL. All four of these may be used for navigation, with `goto()`, `pushState()` and `replaceState()` being intended solely for internal navigation (i.e. not leaving the site), while `<a>` tags may be used for both internal and external navigation. When using any way of internal navigation, the URL must be resolved using SvelteKit's `resolve()`, otherwise the site may break when [configured to live on a non-root path](https://svelte.dev/docs/kit/configuration#paths). For programmatic navigation to external URLs, using `window.location` is advised.
 
 This rule checks all 4 navigation options for the presence of the `resolve()` function call, with an exception for `<a>` links to absolute URLs (and fragment URLs), which are assumed to be used for external navigation and so do not require the `resolve()` function, and for shallow routing functions with an empty string as the path, which keeps the current URL.
 


### PR DESCRIPTION
I was completely baffled by the explanation at https://sveltejs.github.io/eslint-plugin-svelte/rules/no-navigation-without-resolve/ , since I had no idea there was even a possibility to configure the base URL of an app.

Before finding the docs I assumed the "Found a link with a url that isn't resolved." message shown in VS code meant it couldn't find my API route (cf. https://github.com/sveltejs/kit/issues/13195), which I was accessing like this: `<a href="/report/download>Download</a>` — perhaps "Found a link with a URL that would break if the app is configured with a non-root base path" would be clearer?