### PR TITLE
fix(no-unused-props): validate spread operator properly

### DIFF
--- a/.changeset/real-books-stare.md
+++ b/.changeset/real-books-stare.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix(no-unused-props): validate spread operator properly

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested1-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested1-input.svelte
@@ -1,0 +1,16 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: string;
+		b: {
+			c: string;
+			d: number;
+		};
+	}
+
+	let props: Props = $props();
+</script>
+
+<Test a={props.a} {...props.b} />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested2-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested2-input.svelte
@@ -1,0 +1,16 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: string;
+		b: {
+			c: string;
+			d: number;
+		};
+	}
+
+	let { a, b }: Props = $props();
+</script>
+
+<Test {a} {...b} />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested3-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested3-input.svelte
@@ -1,0 +1,15 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: {
+			c: string;
+			d: number;
+		};
+	}
+
+	let props: Props = $props();
+</script>
+
+<Test {...props.a} />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested4-config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested4-config.json
@@ -1,0 +1,7 @@
+{
+	"options": [
+		{
+			"allowUnusedNestedProperties": true
+		}
+	]
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested4-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested4-input.svelte
@@ -1,0 +1,15 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: {
+			c: string;
+			d: number;
+		};
+	}
+
+	let props: Props = $props();
+</script>
+
+<Test {...props.a} />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested5-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested5-input.svelte
@@ -1,0 +1,18 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: string;
+		b: {
+			c: string;
+			d: number;
+		};
+	}
+
+	let props: Props = $props();
+
+	console.log(...props);
+</script>
+
+<Test />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root1-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root1-input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: string;
+	}
+
+	let props: Props = $props();
+</script>
+
+<Test {...props} />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root2-config.json
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root2-config.json
@@ -1,0 +1,7 @@
+{
+	"options": [
+		{
+			"allowUnusedNestedProperties": true
+		}
+	]
+}

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root2-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root2-input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: string;
+	}
+
+	let props: Props = $props();
+</script>
+
+<Test {...props} />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root3-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-root3-input.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Test from '$lib/Test.svelte';
+
+	interface Props {
+		a: string;
+	}
+
+	let props: Props = $props();
+
+	console.log(...props);
+</script>
+
+<Test />


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1369

I’m not entirely satisfied with this fix, but making the code better would take quite a bit more time, so I’m submitting the PR as-is for now.