### PR TITLE
fix(no-navigation-without-resolve): do not report parent-directory relative urls in anchor links

### DIFF
--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
@@ -227,6 +227,7 @@ function checkLinkAttribute(
 		!isValueAllowed(new FindVariableContext(context), value, resolveReferences, {
 			allowAbsolute: true,
 			allowFragment: true,
+			allowParentDirectoryRelative: true,
 			allowNullish: true
 		})
 	) {
@@ -277,6 +278,7 @@ function isValueAllowed(
 		allowAbsolute?: boolean;
 		allowEmpty?: boolean;
 		allowFragment?: boolean;
+		allowParentDirectoryRelative?: boolean;
 		allowNullish?: boolean;
 	}
 ): boolean {
@@ -295,6 +297,7 @@ function isValueAllowed(
 		(config.allowAbsolute && expressionIsAbsoluteUrl(ctx, value)) ||
 		(config.allowEmpty && expressionIsEmpty(value)) ||
 		(config.allowFragment && expressionStartsWith(ctx, value, '#')) ||
+		(config.allowParentDirectoryRelative && expressionStartsWith(ctx, value, '..')) ||
 		(config.allowNullish && expressionIsNullish(value)) ||
 		expressionIsResolveCall(ctx, value, resolveReferences)
 	) {

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-relative-url01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-relative-url01-input.svelte
@@ -1,0 +1,11 @@
+<script>
+	const value = '../';
+	const href = '../';
+</script>
+
+<a href="..">Click me!</a>
+<a href="../">Click me!</a>
+<a href="../other">Click me!</a>
+<a href={'..' + '/other'}>Click me!</a>
+<a href={value}>Click me!</a>
+<a {href}>Click me!</a>


### PR DESCRIPTION
updated (without refactor): https://github.com/sveltejs/eslint-plugin-svelte/pull/1383#issuecomment-4020166705