### PR TITLE
fix(no-navigation-without-resolve): allowing undefined and null in link hrefs

### DIFF
--- a/.changeset/public-groups-prove.md
+++ b/.changeset/public-groups-prove.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix(no-navigation-without-resolve): allowing undefined and null in link hrefs

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-nullish-like-literal01-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-nullish-like-literal01-errors.yaml
@@ -1,0 +1,40 @@
+- message: Unexpected href link without resolve().
+  line: 6
+  column: 10
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 7
+  column: 10
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 8
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 9
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 10
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 11
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 12
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 13
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 14
+  column: 9
+  suggestions: null
+- message: Unexpected href link without resolve().
+  line: 15
+  column: 9
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-nullish-like-literal01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/invalid/link-nullish-like-literal01-input.svelte
@@ -1,0 +1,15 @@
+<script>
+	const one = "undefined";
+	const two = "null";
+</script>
+
+<a href="undefined">Click me!</a>
+<a href="null">Click me!</a>
+<a href={one}>Click me!</a>
+<a href={two}>Click me!</a>
+<a href={`undefined`}>Click me!</a>
+<a href={`null`}>Click me!</a>
+<a href={`${undefined}`}>Click me!</a>
+<a href={`${null}`}>Click me!</a>
+<a href={`${one}`}>Click me!</a>
+<a href={`${two}`}>Click me!</a>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-nullish01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-nullish01-input.svelte
@@ -1,0 +1,9 @@
+<script>
+	const one = undefined;
+	const two = null;
+</script>
+
+<a href={undefined}>Click me!</a>
+<a href={null}>Click me!</a>
+<a href={one}>Click me!</a>
+<a href={two}>Click me!</a>


### PR DESCRIPTION
Fixes #1336
