### PR TITLE
docs: update vs code eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,14 +226,7 @@ export default [
 ## Editor Integrations
 
 **Visual Studio Code**\
-Install [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).\
-Configure `.svelte` files in `.vscode/settings.json`:
-
-```json
-{
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact", "svelte"]
-}
-```
+Install [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
 
 <!--USAGE_GUIDE_END-->
 <!--USAGE_SECTION_END-->


### PR DESCRIPTION
ESLint errors were not being shown on typescript (`.ts`) files opened in VS Code.

Reference https://github.com/microsoft/vscode-eslint/issues/2050