### PR TITLE
chore: allow newer versions of `esrap`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,22 @@ minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
   - '@ota-meshi/*'
+  - '@oxc-project/*'
+  - '@rolldown/*'
+  - '@sveltejs/*'
+  - create-vite
+  - devalue
+  - esm-env
   - esrap
-  - svelte
+  - is-reference
+  - locate-character
+  - rolldown-vite
+  - rolldown
   - svelte-eslint-parser
+  - svelte
   - typescript-eslint-parser-for-extra-files
+  - vite
+  - zimmerframe
 
 packages:
   - 'packages/*'


### PR DESCRIPTION
it's currently failing on the svelte-ecosystem-ci

list of first-party packages taken from https://github.com/sveltejs/vite-plugin-svelte/blob/48e497728f87a07a483dabc57582795c2787c39c/pnpm-workspace.yaml#L9

see also https://github.com/sveltejs/svelte-eslint-parser/pull/796