### PR TITLE
docs(no-navigation-without-resolve): add <a rel="external" ...> example

### DIFF
--- a/docs/rules/no-navigation-without-resolve.md
+++ b/docs/rules/no-navigation-without-resolve.md
@@ -48,6 +48,7 @@ This rule checks all 4 navigation options for the presence of the `resolve()` fu
 <!-- ✓ GOOD -->
 <a href={resolve('/foo/')}>Click me!</a>
 <a href="https://svelte.dev">Click me!</a>
+<a href={someURL} rel="external">Click me!</a>
 
 <!-- ✗ BAD -->
 <a href="/foo">Click me!</a>


### PR DESCRIPTION
This rule behavior is not obvious from description and is implemented.

There is also https://github.com/sveltejs/eslint-plugin-svelte/pull/1380 with more work done, but with conflicts.