### PR TITLE
fix(no-navigation-without-resolve): fixed nullish link shorthands not being allowed

### DIFF
--- a/.changeset/perky-chefs-hope.md
+++ b/.changeset/perky-chefs-hope.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix(no-navigation-without-resolve): fixed nullish link shorthands not being allowed

--- a/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-navigation-without-resolve.ts
@@ -104,6 +104,7 @@ export default createRule('no-navigation-without-resolve', {
 					return;
 				}
 				if (
+					!expressionIsNullish(new FindVariableContext(context), node.value) &&
 					!expressionIsAbsolute(new FindVariableContext(context), node.value) &&
 					!expressionIsFragment(new FindVariableContext(context), node.value) &&
 					!isResolveCall(new FindVariableContext(context), node.value, resolveReferences)

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-nullish01-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-navigation-without-resolve/valid/link-nullish01-input.svelte
@@ -1,9 +1,11 @@
 <script>
 	const one = undefined;
 	const two = null;
+	const href = null;
 </script>
 
 <a href={undefined}>Click me!</a>
 <a href={null}>Click me!</a>
 <a href={one}>Click me!</a>
 <a href={two}>Click me!</a>
+<a {href}>Click me!</a>


### PR DESCRIPTION
Small one, but needed to be able to unify the logic in the great refactoring of this rule...