### PR TITLE
fix(no-top-level-browser-globals): false positive when browser globals appear inside TypeScript generic type parameters

### DIFF
--- a/.changeset/fix-top-level-browser-globals-state.md
+++ b/.changeset/fix-top-level-browser-globals-state.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix(no-top-level-browser-globals): false positive when browser globals appear inside TypeScript generic type parameters (e.g. `$state<HTMLElement>(...)`).

--- a/packages/eslint-plugin-svelte/src/rules/no-top-level-browser-globals.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-top-level-browser-globals.ts
@@ -38,7 +38,11 @@ export default createRule('no-top-level-browser-globals', {
 		const maybeGuards: MaybeGuard[] = [];
 
 		const functions: (TSESTree.FunctionLike | AST.SvelteSnippetBlock)[] = [];
-		const typeAnnotations: (TSESTree.TypeNode | TSESTree.TSTypeAnnotation)[] = [];
+		const typeAnnotations: (
+			| TSESTree.TypeNode
+			| TSESTree.TSTypeAnnotation
+			| TSESTree.TSTypeParameterInstantiation
+		)[] = [];
 
 		function enterFunction(node: TSESTree.FunctionLike | AST.SvelteSnippetBlock) {
 			if (isTopLevelLocation(node)) {
@@ -46,7 +50,7 @@ export default createRule('no-top-level-browser-globals', {
 			}
 		}
 
-		function enterTypeAnnotation(node: TSESTree.TypeNode | TSESTree.TSTypeAnnotation) {
+		function enterTypeAnnotation(node: TSESTree.TypeNode | TSESTree.TSTypeParameterInstantiation) {
 			if (!isInTypeAnnotation(node)) {
 				typeAnnotations.push(node);
 			}
@@ -123,6 +127,7 @@ export default createRule('no-top-level-browser-globals', {
 			':function': enterFunction,
 			SvelteSnippetBlock: enterFunction,
 			'*.typeAnnotation': enterTypeAnnotation,
+			'*.typeArguments': enterTypeAnnotation,
 			MetaProperty: enterMetaProperty,
 			'Program:exit': verifyGlobalReferences
 		};

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-top-level-browser-globals/valid/state-generic-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-top-level-browser-globals/valid/state-generic-input.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+	const element: HTMLElement | null = null; // fine.
+	const stateElement = $state<HTMLElement | null>(null);
+</script>


### PR DESCRIPTION


fixes #1361