### PR TITLE
fix(eslint-plugin-svelte): Replace `isSpaceBetweenTokens` with `isSpaceBetween`

### DIFF
--- a/packages/eslint-plugin-svelte/src/rules/no-reactive-functions.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-reactive-functions.ts
@@ -54,7 +54,7 @@ export default createRule('no-reactive-functions', {
 									count: 3
 								});
 
-								const noExtraSpace = source.isSpaceBetweenTokens(
+								const noExtraSpace = source.isSpaceBetween(
 									tokens[1] as AST.Token,
 									tokens[2] as AST.Token
 								);

--- a/packages/eslint-plugin-svelte/src/types.ts
+++ b/packages/eslint-plugin-svelte/src/types.ts
@@ -260,11 +260,9 @@ export interface SourceCode {
 		trailing: AST.Comment[];
 	};
 
-	getJSDocComment(node: NodeOrToken): AST.Comment | null;
-
 	getNodeByRangeIndex(index: number): ASTNodeWithParent | null;
 
-	isSpaceBetweenTokens(first: AST.Token, second: AST.Token): boolean;
+	isSpaceBetween(first: AST.Token, second: AST.Token): boolean;
 
 	getLocFromIndex(index: number): AST.Position;
 


### PR DESCRIPTION
This PR removes usage of `isSpaceBetweenToken` and replaces it with `isSpaceBetween`, since the former has been deprecated.

Solves #1515.