### PR TITLE
ci: declare contents:read on Node CI workflow

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -15,6 +15,9 @@ defaults:
     #  plus, every platform supports it
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `.github/workflows/NodeCI.yml` to `permissions: contents: read` at the workflow level. The lint/build/test jobs only check out, set up pnpm and Node, install with `--frozen-lockfile`, and run the project scripts. None of them touch a GitHub API beyond the initial checkout.

The motivation here is supply-chain blast-radius capping. CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) demonstrated a tampered third-party action leaking `GITHUB_TOKEN` from the workflow logs - the leaked token carries whatever scope the workflow was issued, so per-workflow caps are the most reliable way to bound that runtime authority. The explicit in-file declaration also gives drift protection if the repo or org default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check (which only credits explicit declarations). The actions used in this file are already SHA-pinned so the rest of the supply-chain hygiene is already strong; this closes the workflow-token side.

YAML validated locally with `yaml.safe_load`.
