### PR TITLE
ci: declare contents:read on pkg.pr.new workflow

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
     tags: ['!**']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'sveltejs/eslint-plugin-svelte'


### PR DESCRIPTION
Declares `permissions: contents: read` at the workflow level on `.github/workflows/pkg.pr.new.yml`. The publish step passes `--comment=off` to `pkg-pr-new`, so no PR commenting occurs and `pull-requests: write` is not needed. The `actions/github-script` step only mutates a local JSON file, and `actions/upload-artifact` writes to the run's artifact scope. `GITHUB_TOKEN` is used by `pkg-pr-new` for publisher identity verification (a read operation).

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is why a per-workflow declaration matters in practice: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the blast radius matched the token's issued scope. Capping each workflow at its actual minimum bounds the runtime authority no matter what the repo or org default is set to. The block also gives drift protection if that default ever widens and is what OpenSSF Scorecard's Token-Permissions check credits.

YAML validated locally with `yaml.safe_load`.
