### PR TITLE
Show fixture filenames in generated rule tests

### DIFF
--- a/packages/eslint-plugin-svelte/tests/utils/utils.ts
+++ b/packages/eslint-plugin-svelte/tests/utils/utils.ts
@@ -69,6 +69,11 @@ export function getRuleFixturesRoot(ruleName: string): string {
 	return path.resolve(FIXTURES_ROOT, `./rules/${ruleName}`);
 }
 
+function getFixtureTestName(inputFile: string): string {
+	const fixturePath = path.relative(FIXTURES_ROOT, inputFile).split(path.sep).join(path.posix.sep);
+	return `tests/fixtures/${fixturePath}`;
+}
+
 function fileNameSuffix(fileName: string): string {
 	return fileName.match(/\.svelte\.(?:j|t)s$/u)
 		? fileName.slice(fileName.length - 10)
@@ -121,7 +126,10 @@ export function loadTestCases(
 
 	const valid = listupInput(validFixtureRoot)
 		.filter(filter)
-		.map((inputFile) => getConfig(ruleName, inputFile));
+		.map((inputFile) => ({
+			...getConfig(ruleName, inputFile),
+			name: getFixtureTestName(inputFile)
+		}));
 
 	const fixable = plugin.rules[ruleName].meta?.fixable != null;
 
@@ -165,7 +173,10 @@ export function loadTestCases(
 				config.output = output === config.code ? null : output;
 			}
 
-			return config;
+			return {
+				...config,
+				name: getFixtureTestName(inputFile)
+			};
 		});
 
 	if (options?.additionals) {


### PR DESCRIPTION
Fixture-based rule failures could be hard to track back to the actual `.svelte` file because the generated test name did not include the fixture path.

This adds the relative fixture input path to generated valid and invalid test names, while keeping the real input file path as the test `filename`. I checked it with the focused fixture rule run passing 8 tests, the full plugin suite passing 1,427 tests, lint, and `git diff --check`.

Fixes #1508