### PR TITLE
feat: report useless template literal mustaches

### DIFF
--- a/.changeset/tidy-mustaches-smile.md
+++ b/.changeset/tidy-mustaches-smile.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': minor
+---
+
+feat: add prefer-attribute-interpolation rule

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 | [svelte/no-extra-reactive-curlies](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-extra-reactive-curlies/) | disallow wrapping single reactive statements in curly braces | :bulb: |
 | [svelte/no-restricted-html-elements](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-restricted-html-elements/) | disallow specific HTML elements |  |
 | [svelte/no-spaces-around-equal-signs-in-attribute](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-spaces-around-equal-signs-in-attribute/) | disallow spaces around equal signs in attribute | :wrench: |
+| [svelte/prefer-attribute-interpolation](https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-attribute-interpolation/) | require attribute interpolation instead of template literals |  |
 | [svelte/prefer-class-directive](https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-class-directive/) | require class directives instead of ternary expressions | :wrench: |
 | [svelte/prefer-style-directive](https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-style-directive/) | require style directives instead of style attribute | :wrench: |
 | [svelte/require-event-prefix](https://sveltejs.github.io/eslint-plugin-svelte/rules/require-event-prefix/) | require component event names to start with "on" |  |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,6 +102,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 | [svelte/no-extra-reactive-curlies](./rules/no-extra-reactive-curlies.md)                                 | disallow wrapping single reactive statements in curly braces                       | :bulb:   |
 | [svelte/no-restricted-html-elements](./rules/no-restricted-html-elements.md)                             | disallow specific HTML elements                                                    |          |
 | [svelte/no-spaces-around-equal-signs-in-attribute](./rules/no-spaces-around-equal-signs-in-attribute.md) | disallow spaces around equal signs in attribute                                    | :wrench: |
+| [svelte/prefer-attribute-interpolation](./rules/prefer-attribute-interpolation.md)                       | require attribute interpolation instead of template literals                       |          |
 | [svelte/prefer-class-directive](./rules/prefer-class-directive.md)                                       | require class directives instead of ternary expressions                            | :wrench: |
 | [svelte/prefer-style-directive](./rules/prefer-style-directive.md)                                       | require style directives instead of style attribute                                | :wrench: |
 | [svelte/require-event-prefix](./rules/require-event-prefix.md)                                           | require component event names to start with "on"                                   |          |

--- a/docs/rules/prefer-attribute-interpolation.md
+++ b/docs/rules/prefer-attribute-interpolation.md
@@ -1,0 +1,53 @@
+---
+pageClass: 'rule-details'
+sidebarDepth: 0
+title: 'svelte/prefer-attribute-interpolation'
+description: 'require attribute interpolation instead of template literals'
+---
+
+# svelte/prefer-attribute-interpolation
+
+> require attribute interpolation instead of template literals
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+
+## :book: Rule Details
+
+This rule reports a dynamic JavaScript template literal used as an attribute's entire value.
+Svelte's attribute interpolation syntax can represent the same value without the enclosing template
+literal.
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/prefer-attribute-interpolation: "error" */
+  let name = 'world';
+</script>
+
+<!-- ✓ GOOD -->
+<div title="Hello {name}" />
+
+<!-- ✗ BAD -->
+<div title={`Hello ${name}`} />
+```
+
+Embedded template literals, conditional expressions, style directives, template literals containing
+comments, escapes with distinct runtime semantics, line breaks, or raw opening braces, and string
+concatenation are not reported. String concatenation can be handled separately with ESLint's
+[`prefer-template`] rule.
+
+## :wrench: Options
+
+Nothing.
+
+## :couple: Related Rules
+
+- [`prefer-template`]
+
+[`prefer-template`]: https://eslint.org/docs/latest/rules/prefer-template
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/rules/prefer-attribute-interpolation.ts)
+- [Test source](https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/tests/src/rules/prefer-attribute-interpolation.ts)

--- a/packages/eslint-plugin-svelte/src/rule-types.ts
+++ b/packages/eslint-plugin-svelte/src/rule-types.ts
@@ -329,6 +329,11 @@ export interface RuleOptions {
    */
   'svelte/no-useless-mustaches'?: Linter.RuleEntry<SvelteNoUselessMustaches>
   /**
+   * require attribute interpolation instead of template literals
+   * @see https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-attribute-interpolation/
+   */
+  'svelte/prefer-attribute-interpolation'?: Linter.RuleEntry<[]>
+  /**
    * require class directives instead of ternary expressions
    * @see https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-class-directive/
    */

--- a/packages/eslint-plugin-svelte/src/rules/prefer-attribute-interpolation.ts
+++ b/packages/eslint-plugin-svelte/src/rules/prefer-attribute-interpolation.ts
@@ -1,0 +1,82 @@
+import type { AST } from 'svelte-eslint-parser';
+import { createRule } from '../utils/index.js';
+
+/** Check whether an escape has distinct runtime semantics. */
+function hasUsefulStringEscape(rawValue: string, strValue: string): boolean {
+	if (rawValue === strValue) {
+		return false;
+	}
+
+	const chars = [...rawValue];
+	let char = chars.shift();
+	while (char) {
+		if (char === '\\') {
+			char = chars.shift();
+			if (char == null || 'nrvtbfux'.includes(char)) {
+				return true;
+			}
+		}
+		char = chars.shift();
+	}
+	return false;
+}
+
+export default createRule('prefer-attribute-interpolation', {
+	meta: {
+		docs: {
+			description: 'require attribute interpolation instead of template literals',
+			category: 'Stylistic Issues',
+			recommended: false,
+			conflictWithPrettier: false
+		},
+		schema: [],
+		messages: {
+			unexpected: 'Prefer attribute interpolation over a template literal.'
+		},
+		type: 'suggestion'
+	},
+	create(context) {
+		const sourceCode = context.sourceCode;
+
+		return {
+			SvelteAttribute(node: AST.SvelteAttribute) {
+				if (node.value.length !== 1) {
+					return;
+				}
+
+				const value = node.value[0];
+				if (
+					value.type !== 'SvelteMustacheTag' ||
+					value.expression.type !== 'TemplateLiteral' ||
+					value.expression.expressions.length === 0
+				) {
+					return;
+				}
+
+				if (
+					sourceCode
+						.getTokens(value, { includeComments: true })
+						.some((token) => token.type === 'Block' || token.type === 'Line')
+				) {
+					return;
+				}
+
+				if (
+					value.expression.quasis.some(
+						(quasi) =>
+							/[\n\r]/u.test(quasi.value.raw) ||
+							quasi.value.raw.includes('{') ||
+							hasUsefulStringEscape(quasi.value.raw, quasi.value.cooked ?? quasi.value.raw)
+					)
+				) {
+					return;
+				}
+
+				context.report({
+					node: value,
+					messageId: 'unexpected'
+				});
+			}
+		};
+	}
+});

--- a/packages/eslint-plugin-svelte/src/utils/rules.ts
+++ b/packages/eslint-plugin-svelte/src/utils/rules.ts
@@ -64,6 +64,7 @@ import noUnusedProps from '../rules/no-unused-props.js';
 import noUnusedSvelteIgnore from '../rules/no-unused-svelte-ignore.js';
 import noUselessChildrenSnippet from '../rules/no-useless-children-snippet.js';
 import noUselessMustaches from '../rules/no-useless-mustaches.js';
+import preferAttributeInterpolation from '../rules/prefer-attribute-interpolation.js';
 import preferClassDirective from '../rules/prefer-class-directive.js';
 import preferConst from '../rules/prefer-const.js';
 import preferDerivedOverDerivedBy from '../rules/prefer-derived-over-derived-by.js';
@@ -151,6 +152,7 @@ export const rules = [
 	noUnusedSvelteIgnore,
 	noUselessChildrenSnippet,
 	noUselessMustaches,
+	preferAttributeInterpolation,
 	preferClassDirective,
 	preferConst,
 	preferDerivedOverDerivedBy,

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-errors.yaml
@@ -1,0 +1,12 @@
+- message: Prefer attribute interpolation over a template literal.
+  line: 6
+  column: 11
+  suggestions: null
+- message: Prefer attribute interpolation over a template literal.
+  line: 7
+  column: 16
+  suggestions: null
+- message: Prefer attribute interpolation over a template literal.
+  line: 9
+  column: 12
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-input.svelte
@@ -1,0 +1,9 @@
+<script>
+	let foo = 'foo';
+	let bar = 'bar';
+</script>
+
+<Foo attr={`prefix${foo}`} />
+<div data-text={`prefix${foo}${bar}`} />
+<!-- prettier-ignore -->
+<Foo attr="{`prefix${foo}`}" />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-output.svelte
@@ -1,0 +1,9 @@
+<script>
+	let foo = 'foo';
+	let bar = 'bar';
+</script>
+
+<Foo attr={`prefix${foo}`} />
+<div data-text={`prefix${foo}${bar}`} />
+<!-- prettier-ignore -->
+<Foo attr="{`prefix${foo}`}" />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-output.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/invalid/template-literal-attribute-output.svelte
@@ -1,9 +1,0 @@
-<script>
-	let foo = 'foo';
-	let bar = 'bar';
-</script>
-
-<Foo attr={`prefix${foo}`} />
-<div data-text={`prefix${foo}${bar}`} />
-<!-- prettier-ignore -->
-<Foo attr="{`prefix${foo}`}" />

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/valid/boundaries-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/prefer-attribute-interpolation/valid/boundaries-input.svelte
@@ -1,0 +1,18 @@
+<script>
+	let foo = 'foo';
+</script>
+
+<div data-text="prefix {`foo${foo}`} suffix" />
+<div data-text={foo ? `foo${foo}` : 'bar'} />
+<div data-text={`prefix${/* comment */ foo}`} />
+<div data-text={`line\n${foo}`} />
+<div data-text={`prefix{${foo}`} />
+<div style:color={`rgb(${foo})`} />
+<div data-text={'prefix' + foo} />
+<div data-text={`static`} />
+
+<HyperMD
+	value={`# ${foo}
+
+Text goes here`}
+/>

--- a/packages/eslint-plugin-svelte/tests/src/rules/prefer-attribute-interpolation.ts
+++ b/packages/eslint-plugin-svelte/tests/src/rules/prefer-attribute-interpolation.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from '../../utils/eslint-compat.js';
+import rule from '../../../src/rules/prefer-attribute-interpolation.js';
+import { loadTestCases } from '../../utils/utils.js';
+
+const tester = new RuleTester({
+	languageOptions: {
+		ecmaVersion: 'latest',
+		sourceType: 'module'
+	}
+});
+
+tester.run(
+	'prefer-attribute-interpolation',
+	rule as any,
+	loadTestCases('prefer-attribute-interpolation')
+);


### PR DESCRIPTION
Closes #893.

## Summary
- extend svelte/no-useless-mustaches to report dynamic template literals used as an entire attribute value
- keep embedded, conditional, style-directive, comment, escape, multiline, and raw-brace cases exempt
- add fixture coverage, documentation, and a changeset

The new diagnostic is intentionally report-only because a safe conversion must account for Svelte attribute escaping.

## Validation
- focused rule suite: 12 passing
- full workspace suite: 1,455 passing
- package build and docs production build
- targeted ESLint, docs lint, Prettier, and git diff --check