### PR TITLE
fix(no-unused-props): treat an object spread as consuming every nested property

### DIFF
--- a/.changeset/clever-pandas-shave.md
+++ b/.changeset/clever-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-svelte': patch
+---
+
+fix: `svelte/no-unused-props` false positive when an object prop is consumed via an object spread and also accessed directly

--- a/.changeset/clever-pandas-shave.md
+++ b/.changeset/clever-pandas-shave.md
@@ -2,4 +2,4 @@
 'eslint-plugin-svelte': patch
 ---
 
-fix: `svelte/no-unused-props` false positive when an object prop is consumed via an object spread and also accessed directly
+fix: `svelte/no-unused-props` false positive when a prop is consumed via an object spread and also accessed by name

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
@@ -315,21 +315,20 @@ export default createRule('no-unused-props', {
 
 				if (reportedPropertyPaths.has(currentPathStr)) continue;
 
-				const propType = typeChecker.getTypeOfSymbol(prop);
-
-				// A spread of this property, or of anything containing it, consumes
-				// every property beneath it, so there is nothing left to report
-				// even when some of them are also accessed individually.
-				const isSpreadInThisPath = usedSpreadPropertyPaths.some((path) => {
+				// Spreading this property, or any of its ancestors, consumes everything
+				// beneath it, so nothing under it can be reported -- even when some of
+				// those properties are also read by name.
+				const isCoveredBySpread = usedSpreadPropertyPaths.some((path) => {
 					return path === '' || path === currentPathStr || currentPathStr.startsWith(`${path}.`);
 				});
-				if (isSpreadInThisPath) continue;
+				if (isCoveredBySpread) continue;
+
+				const propType = typeChecker.getTypeOfSymbol(prop);
 
 				const isUsedThisInPath =
 					usedPropertyPaths.includes(currentPathStr) ||
-					usedSpreadPropertyPaths.some((path) => {
-						return path === '' || path === currentPathStr || path.startsWith(`${currentPathStr}.`);
-					});
+					// A spread deeper inside this property counts as using the property itself.
+					usedSpreadPropertyPaths.some((path) => path.startsWith(`${currentPathStr}.`));
 				const isUsedInPath = usedPropertyPaths.some((path) => {
 					return path.startsWith(`${currentPathStr}.`);
 				});

--- a/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
+++ b/packages/eslint-plugin-svelte/src/rules/no-unused-props.ts
@@ -317,6 +317,14 @@ export default createRule('no-unused-props', {
 
 				const propType = typeChecker.getTypeOfSymbol(prop);
 
+				// A spread of this property, or of anything containing it, consumes
+				// every property beneath it, so there is nothing left to report
+				// even when some of them are also accessed individually.
+				const isSpreadInThisPath = usedSpreadPropertyPaths.some((path) => {
+					return path === '' || path === currentPathStr || currentPathStr.startsWith(`${path}.`);
+				});
+				if (isSpreadInThisPath) continue;
+
 				const isUsedThisInPath =
 					usedPropertyPaths.includes(currentPathStr) ||
 					usedSpreadPropertyPaths.some((path) => {

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/spread-sibling-unused-errors.yaml
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/spread-sibling-unused-errors.yaml
@@ -1,0 +1,4 @@
+- message: "'z' in 'b' is an unused property."
+  line: 8
+  column: 6
+  suggestions: null

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/spread-sibling-unused-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/invalid/spread-sibling-unused-input.svelte
@@ -1,0 +1,13 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	interface Props {
+		a: { x: string; y: string };
+		b: { z: string };
+	}
+
+	let { a, b }: Props = $props();
+
+	const data = { ...a, x: a.x };
+</script>
+
+<p>{data.x}</p>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested6-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-nested6-input.svelte
@@ -1,0 +1,14 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	interface Props {
+		a: {
+			b: { c: string; d: number };
+		};
+	}
+
+	let { a }: Props = $props();
+
+	const data = { ...a.b, c: a.b.c };
+</script>
+
+<p>{data.c}</p>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-object-expression-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-object-expression-input.svelte
@@ -1,0 +1,11 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	type Props = {
+		app: { name: string; description: string };
+	};
+	const { app }: Props = $props();
+
+	const data = { ...app, name: `${app.name} (copy)` };
+</script>
+
+<p>{data.name}</p>

--- a/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-prefix-collision-input.svelte
+++ b/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props/valid/spread-prefix-collision-input.svelte
@@ -1,0 +1,13 @@
+<!--Test1.svelte-->
+<script lang="ts">
+	interface Props {
+		a: { z: string };
+		ab: { x: string };
+	}
+
+	let { a, ab }: Props = $props();
+
+	const data = { ...a, z: a.z };
+</script>
+
+<p>{data.z}{ab.x}</p>


### PR DESCRIPTION
Fixes #1556.

Spreading a prop into an object literal consumes all of its properties, but the rule still reported the ones that were not also accessed by name:

```svelte
<script lang="ts">
	type Props = {
		app: { name: string; description: string };
	};
	const { app }: Props = $props();

	const data = { ...app, name: `${app.name} (copy)` };
</script>

<p>{data.name}</p>
```

gives `'description' in 'app' is an unused property`.

The spread itself is already recorded: `getPropertyPath` sets `isSpread` for a `SpreadElement` parent, so `usedSpreadPropertyPaths` contains `app`. The problem is downstream in `checkUnusedProperties`:

```js
const isUsedThisInPath = usedPropertyPaths.includes(currentPathStr) || usedSpreadPropertyPaths.some(...);
const isUsedInPath = usedPropertyPaths.some((path) => path.startsWith(`${currentPathStr}.`));

if (isUsedThisInPath && !isUsedInPath) {
	continue;
}
```

For `app` both are true, since `app.name` is a direct access, so the early continue does not fire and the walk descends into `app` and reports `description`. In other words the spread coverage is silently dropped as soon as any nested property is also read by name. Removing `${app.name}` from the example makes the report go away, which is what made this look like a spread-detection problem rather than a precedence one.

This adds a check before that block: if a spread covers this exact path, or any ancestor of it, skip the property entirely, since everything beneath it has flowed into the spread target.

Existing behavior is unchanged elsewhere. The `path === ''` case (a root `$props()` spread) and the "spread deeper inside marks the parent used" case both still go through `isUsedThisInPath`.

Test is a valid fixture, `spread-object-expression-input.svelte`, holding the snippet from the issue. It reports one error before the change and none after. Full suite is 1455 passing.
